### PR TITLE
Dropdown menu for Today, allowing to view This Week and This Month

### DIFF
--- a/apps/server/src/routes/__tests__/dashboard.test.ts
+++ b/apps/server/src/routes/__tests__/dashboard.test.ts
@@ -138,8 +138,8 @@ describe('Dashboard Stats Routes', () => {
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
       expect(body).toEqual(cachedStats);
-      // Cache key now includes timezone (defaults to UTC)
-      expect(redisMock.get).toHaveBeenCalledWith(`${REDIS_KEYS.DASHBOARD_STATS}:UTC`);
+      // Cache key now includes timezone and period (defaults to UTC / day)
+      expect(redisMock.get).toHaveBeenCalledWith(`${REDIS_KEYS.DASHBOARD_STATS}:day:na:na:UTC`);
       // Should not call database when cache hit
       expect(playsCountSince.execute).not.toHaveBeenCalled();
     });
@@ -176,7 +176,7 @@ describe('Dashboard Stats Routes', () => {
 
       // Should cache the results (cache key includes timezone)
       expect(redisMock.setex).toHaveBeenCalledWith(
-        `${REDIS_KEYS.DASHBOARD_STATS}:UTC`,
+        `${REDIS_KEYS.DASHBOARD_STATS}:day:na:na:UTC`,
         60,
         expect.any(String)
       );

--- a/apps/web/src/hooks/queries/useStats.ts
+++ b/apps/web/src/hooks/queries/useStats.ts
@@ -5,12 +5,21 @@ import { api, type StatsTimeRange, getBrowserTimezone } from '@/lib/api';
 // Re-export for backwards compatibility and convenience
 export type { StatsTimeRange };
 
-export function useDashboardStats(serverId?: string | null) {
+export function useDashboardStats(serverId?: string | null, timeRange?: StatsTimeRange) {
   // Include timezone in cache key since "today" varies by timezone
   const timezone = getBrowserTimezone();
+  const range = timeRange ?? { period: 'day' };
   return useQuery({
-    queryKey: ['stats', 'dashboard', serverId, timezone],
-    queryFn: () => api.stats.dashboard(serverId ?? undefined),
+    queryKey: [
+      'stats',
+      'dashboard',
+      serverId,
+      timezone,
+      range.period,
+      range.startDate,
+      range.endDate,
+    ],
+    queryFn: () => api.stats.dashboard(serverId ?? undefined, { ...range, timezone }),
     staleTime: 1000 * 30, // 30 seconds
     refetchInterval: 1000 * 60, // 1 minute
   });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -620,11 +620,8 @@ class ApiClient {
   }
 
   stats = {
-    dashboard: (serverId?: string) => {
-      const params = new URLSearchParams();
-      if (serverId) params.set('serverId', serverId);
-      // Include timezone so "today" is calculated in user's local timezone
-      params.set('timezone', getBrowserTimezone());
+    dashboard: (serverId?: string, timeRange?: StatsTimeRange) => {
+      const params = this.buildStatsParams(timeRange ?? { period: 'day' }, serverId);
       return this.request<DashboardStats>(`/stats/dashboard?${params.toString()}`);
     },
     plays: async (timeRange?: StatsTimeRange, serverId?: string) => {

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -1,5 +1,15 @@
 import { useState } from 'react';
-import { Play, Clock, AlertTriangle, Tv, MapPin, Calendar, Users, Activity } from 'lucide-react';
+import {
+  Play,
+  Clock,
+  AlertTriangle,
+  Tv,
+  MapPin,
+  Calendar,
+  Users,
+  Activity,
+  ChevronDown,
+} from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { StatCard } from '@/components/ui/stat-card';
 import { NowPlayingCard } from '@/components/sessions';
@@ -10,10 +20,17 @@ import { useDashboardStats, useActiveSessions } from '@/hooks/queries';
 import { useServerStatistics } from '@/hooks/queries/useServers';
 import { useServer } from '@/hooks/useServer';
 import type { ActiveSession } from '@tracearr/shared';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 export function Dashboard() {
   const { selectedServerId, selectedServer } = useServer();
-  const { data: stats, isLoading: statsLoading } = useDashboardStats(selectedServerId);
+  const [period, setPeriod] = useState<'day' | 'week' | 'month'>('day');
+  const { data: stats, isLoading: statsLoading } = useDashboardStats(selectedServerId, { period });
   const { data: sessions } = useActiveSessions(selectedServerId);
 
   // Session detail sheet state
@@ -32,6 +49,7 @@ export function Dashboard() {
 
   const activeCount = sessions?.length ?? 0;
   const hasActiveStreams = activeCount > 0;
+  const periodLabel = period === 'week' ? 'This Week' : period === 'month' ? 'This Month' : 'Today';
 
   return (
     <div className="space-y-6">
@@ -39,7 +57,24 @@ export function Dashboard() {
       <section>
         <div className="mb-4 flex items-center gap-2">
           <Calendar className="text-primary h-5 w-5" />
-          <h2 className="text-lg font-semibold">Today</h2>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="hover:text-primary text-left text-lg font-semibold outline-none"
+              >
+                <span className="inline-flex items-center gap-1">
+                  {periodLabel}
+                  <ChevronDown className="h-4 w-4" />
+                </span>
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem onSelect={() => setPeriod('day')}>Today</DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setPeriod('week')}>This Week</DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setPeriod('month')}>This Month</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           <StatCard

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -218,15 +218,11 @@ export const timezoneSchema = z
   .refine(isValidTimezone, { message: 'Invalid IANA timezone identifier' })
   .optional();
 
-// Dashboard query schema with timezone support
-export const dashboardQuerySchema = z.object({
-  serverId: uuidSchema.optional(),
-  timezone: timezoneSchema,
-});
+const statsPeriodSchema = z.enum(['day', 'week', 'month', 'year', 'all', 'custom']);
 
 export const statsQuerySchema = z
   .object({
-    period: z.enum(['day', 'week', 'month', 'year', 'all', 'custom']).default('week'),
+    period: statsPeriodSchema.default('week'),
     startDate: z.iso.datetime().optional(),
     endDate: z.iso.datetime().optional(),
     serverId: uuidSchema.optional(),
@@ -252,6 +248,12 @@ export const statsQuerySchema = z
     },
     { message: 'startDate must be before endDate' }
   );
+
+// Dashboard query schema with timezone support
+export const dashboardQuerySchema = statsQuerySchema.safeExtend({
+  // Dashboard defaults to "today" while reusing the shared stats query shape
+  period: statsPeriodSchema.default('day'),
+});
 
 // Location stats with full filtering - uses same period system as statsQuerySchema
 export const locationStatsQuerySchema = z


### PR DESCRIPTION
- Adds a minimalistic drop down arrow to Today on Dashboard
- Expanding the drop down presents options for This Week and This Month
- This is not meant to duplicate the history feature, stats are aggregated for This Week (from Sunday to today) and This Month (from 1st of the month until today) for quick peek instead of going to history and running a custom date range.
- Closes #142 

<img width="266" height="140" alt="Screenshot 2026-01-06 at 00 26 50" src="https://github.com/user-attachments/assets/7f754a33-a0ac-471f-973e-9cbf45cd02d8" />

<img width="375" height="158" alt="Screenshot 2026-01-06 at 00 27 21" src="https://github.com/user-attachments/assets/12cefb6c-97a1-43f9-b7de-3ef7e7650bcb" />
