### PR TITLE
Feature: Track server users' last activity date

### DIFF
--- a/apps/server/src/db/migrations/0037_add_server_user_last_activity.sql
+++ b/apps/server/src/db/migrations/0037_add_server_user_last_activity.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "server_users"
+ADD COLUMN "last_activity_at" timestamp with time zone;

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1768236630197,
       "tag": "0036_closed_donald_blake",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1768131686186,
+      "tag": "0037_add_server_user_last_activity",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -199,6 +199,9 @@ export const serverUsers = pgTable(
     // When user joined/was added to media server (Plex provides this, Jellyfin/Emby don't)
     joinedAt: timestamp('joined_at', { withTimezone: true }),
 
+    // Last activity timestamp
+    lastActivityAt: timestamp('last_activity_at', { withTimezone: true }),
+
     // Server-specific permissions
     isServerAdmin: boolean('is_server_admin').notNull().default(false),
 

--- a/apps/server/src/routes/users/full.ts
+++ b/apps/server/src/routes/users/full.ts
@@ -67,6 +67,8 @@ export const fullRoutes: FastifyPluginAsync = async (app) => {
           isServerAdmin: serverUsers.isServerAdmin,
           trustScore: serverUsers.trustScore,
           sessionCount: serverUsers.sessionCount,
+          joinedAt: serverUsers.joinedAt,
+          lastActivityAt: serverUsers.lastActivityAt,
           createdAt: serverUsers.createdAt,
           updatedAt: serverUsers.updatedAt,
           identityName: users.name,

--- a/apps/server/src/routes/users/list.ts
+++ b/apps/server/src/routes/users/list.ts
@@ -83,6 +83,7 @@ export const listRoutes: FastifyPluginAsync = async (app) => {
         trustScore: serverUsers.trustScore,
         sessionCount: serverUsers.sessionCount,
         joinedAt: serverUsers.joinedAt,
+        lastActivityAt: serverUsers.lastActivityAt,
         updatedAt: serverUsers.updatedAt,
         // Include identity info
         identityName: users.name,
@@ -139,6 +140,7 @@ export const listRoutes: FastifyPluginAsync = async (app) => {
         trustScore: serverUsers.trustScore,
         sessionCount: serverUsers.sessionCount,
         joinedAt: serverUsers.joinedAt,
+        lastActivityAt: serverUsers.lastActivityAt,
         updatedAt: serverUsers.updatedAt,
         // Include identity info
         identityName: users.name,
@@ -248,6 +250,7 @@ export const listRoutes: FastifyPluginAsync = async (app) => {
         trustScore: serverUsers.trustScore,
         sessionCount: serverUsers.sessionCount,
         joinedAt: serverUsers.joinedAt,
+        lastActivityAt: serverUsers.lastActivityAt,
         updatedAt: serverUsers.updatedAt,
       });
 

--- a/apps/server/src/test/fixtures.ts
+++ b/apps/server/src/test/fixtures.ts
@@ -479,6 +479,7 @@ export function createMockServerUser(overrides: Partial<ServerUser> = {}): Serve
     trustScore: overrides.trustScore ?? 100,
     sessionCount: overrides.sessionCount ?? 0,
     joinedAt: overrides.joinedAt ?? null,
+    lastActivityAt: overrides.lastActivityAt ?? null,
     createdAt: overrides.createdAt ?? new Date(),
     updatedAt: overrides.updatedAt ?? new Date(),
   };

--- a/apps/web/src/pages/UserDetail.tsx
+++ b/apps/web/src/pages/UserDetail.tsx
@@ -392,29 +392,47 @@ export function UserDetail() {
                   );
                 })()}
               </div>
-              <div className="flex-1 space-y-2">
-                <div className="flex items-center gap-2">
-                  <h2 className="text-xl font-semibold">{user.identityName ?? user.username}</h2>
-                  {isOwner && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7"
-                      onClick={() => setIsEditNameOpen(true)}
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </Button>
-                  )}
-                  {user.role === 'owner' && (
-                    <span title="Server Owner">
-                      <Crown className="h-5 w-5 text-yellow-500" />
-                    </span>
-                  )}
+              <div className="flex flex-1 items-start justify-between gap-6">
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-xl font-semibold">{user.identityName ?? user.username}</h2>
+                    {isOwner && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7"
+                        onClick={() => setIsEditNameOpen(true)}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                    )}
+                    {user.role === 'owner' && (
+                      <span title="Server Owner">
+                        <Crown className="h-5 w-5 text-yellow-500" />
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-muted-foreground text-sm">@{user.username}</p>
+                  {user.email && <p className="text-muted-foreground text-sm">{user.email}</p>}
+                  <div className="flex items-center gap-4 pt-2">
+                    <TrustScoreBadge score={user.trustScore} showLabel />
+                  </div>
                 </div>
-                <p className="text-muted-foreground text-sm">@{user.username}</p>
-                {user.email && <p className="text-muted-foreground text-sm">{user.email}</p>}
-                <div className="flex items-center gap-4 pt-2">
-                  <TrustScoreBadge score={user.trustScore} showLabel />
+                <div className="text-muted-foreground flex flex-col gap-2 text-right text-sm">
+                  <div className="flex items-center gap-2">
+                    <Clock className="h-4 w-4" />
+                    <span className="text-foreground font-medium">Joined</span>
+                    <span>{format(new Date(user.joinedAt ?? user.createdAt), 'MMM d, yyyy')}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Clock className="h-4 w-4" />
+                    <span className="text-foreground font-medium">Last Activity</span>
+                    <span>
+                      {user.lastActivityAt
+                        ? format(new Date(user.lastActivityAt), 'MMM d, yyyy')
+                        : '—'}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -441,15 +459,6 @@ export function UserDetail() {
                   <span className="text-muted-foreground text-sm">Violations</span>
                 </div>
                 <p className="mt-1 text-2xl font-bold">{violationsTotal}</p>
-              </div>
-              <div className="rounded-lg border p-4">
-                <div className="flex items-center gap-2">
-                  <Clock className="text-muted-foreground h-4 w-4" />
-                  <span className="text-muted-foreground text-sm">Joined</span>
-                </div>
-                <p className="mt-1 text-sm font-medium">
-                  {format(new Date(user.createdAt), 'MMM d, yyyy')}
-                </p>
               </div>
               <div className="rounded-lg border p-4">
                 <div className="flex items-center gap-2">

--- a/apps/web/src/pages/Users.tsx
+++ b/apps/web/src/pages/Users.tsx
@@ -65,6 +65,18 @@ const userColumns: ColumnDef<ServerUserWithIdentity>[] = [
       </div>
     ),
   },
+  {
+    accessorKey: 'lastActivityAt',
+    header: 'Last Activity',
+    cell: ({ row }) => (
+      <div className="text-muted-foreground flex items-center gap-2 text-sm">
+        <Clock className="h-4 w-4" />
+        {row.original.lastActivityAt
+          ? formatDistanceToNow(new Date(row.original.lastActivityAt), { addSuffix: true })
+          : 'Never'}
+      </div>
+    ),
+  },
 ];
 
 export function Users() {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -70,6 +70,7 @@ export interface ServerUser {
   trustScore: number;
   sessionCount: number;
   joinedAt: Date | null;
+  lastActivityAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
This PR:
- Add `lastActivityAt` to server user schema, shared types, and session lifecycle logic
- Expose last activity and joined timestamps via user list/full routes.
- Surface joined date and last activity in Users table and User Detail UI.

The `lastActivityAt` is computed based on the latest stream date of any given user.

In the UI, the user list looks like:
![Screenshot 2026-01-11 at 12 31 51](https://github.com/user-attachments/assets/a45f99c0-6105-4b2f-9512-d5122d2cdd9c)

And the user detail view:
![Screenshot 2026-01-11 at 12 33 13](https://github.com/user-attachments/assets/907c88e6-48ec-4925-8711-db478a639ec9)


This also lays the groundwork for https://github.com/connorgallopo/Tracearr/issues/105