### PR TITLE
Add trailer detection for Plex clips

### DIFF
--- a/apps/mobile/app/session/[id].tsx
+++ b/apps/mobile/app/session/[id].tsx
@@ -38,6 +38,7 @@ import {
   Eye,
   ChevronRight,
   X,
+  Clapperboard,
 } from 'lucide-react-native';
 import { api, getServerUrl } from '@/lib/api';
 import { useMediaServer } from '@/providers/MediaServerProvider';
@@ -69,6 +70,7 @@ const MEDIA_CONFIG: Record<MediaType, { icon: typeof Film; label: string }> = {
   track: { icon: Music, label: 'Track' },
   live: { icon: Radio, label: 'Live TV' },
   photo: { icon: ImageIcon, label: 'Photo' },
+  trailer: { icon: Clapperboard, label: 'Trailer' },
   unknown: { icon: CircleHelp, label: 'Unknown' },
 };
 

--- a/apps/server/src/constants/mediaTypes.ts
+++ b/apps/server/src/constants/mediaTypes.ts
@@ -25,9 +25,9 @@ export type PrimaryMediaType = (typeof PRIMARY_MEDIA_TYPES)[number];
 /**
  * Media types excluded from rule evaluation and primary statistics.
  * Live TV and music tracks typically don't represent sharing/abuse patterns.
- * Photos and unknown types are also excluded as they're not typical media consumption.
+ * Photos, trailers and unknown types are also excluded as they're not typical media consumption.
  */
-export const EXCLUDED_MEDIA_TYPES = ['live', 'track', 'photo', 'unknown'] as const;
+export const EXCLUDED_MEDIA_TYPES = ['live', 'track', 'photo', 'trailer', 'unknown'] as const;
 export type ExcludedMediaType = (typeof EXCLUDED_MEDIA_TYPES)[number];
 
 /**

--- a/apps/server/src/services/mediaServer/plex/parser.ts
+++ b/apps/server/src/services/mediaServer/plex/parser.ts
@@ -603,6 +603,8 @@ function parseMediaType(type: unknown, isLive: boolean = false): MediaSession['m
       return 'track';
     case 'photo':
       return 'photo';
+    case 'clip':
+      return 'trailer';
     default:
       return 'unknown';
   }

--- a/apps/server/src/services/mediaServer/types.ts
+++ b/apps/server/src/services/mediaServer/types.ts
@@ -40,7 +40,7 @@ export interface MediaSession {
   /** Media metadata */
   media: {
     title: string;
-    type: 'movie' | 'episode' | 'track' | 'live' | 'photo' | 'unknown';
+    type: 'movie' | 'episode' | 'track' | 'live' | 'photo' | 'trailer' | 'unknown';
     /** Duration in milliseconds */
     durationMs: number;
     /** Release year */
@@ -329,7 +329,7 @@ export interface MediaWatchHistoryItem {
   /** Item title */
   title: string;
   /** Media type */
-  type: 'movie' | 'episode' | 'track' | 'live' | 'photo' | 'unknown';
+  type: 'movie' | 'episode' | 'track' | 'live' | 'photo' | 'trailer' | 'unknown';
   /** When item was last watched (Unix timestamp or ISO string) */
   watchedAt: number | string;
   /** User ID who watched (if available) */

--- a/apps/web/src/components/history/HistoryTable.tsx
+++ b/apps/web/src/components/history/HistoryTable.tsx
@@ -22,6 +22,7 @@ import {
   ArrowUpDown,
   ArrowUp,
   ArrowDown,
+  Clapperboard,
 } from 'lucide-react';
 import {
   Table,
@@ -176,6 +177,7 @@ function MediaTypeIcon({ type }: { type: MediaType }) {
     track: { icon: Music, label: 'Music' },
     live: { icon: Radio, label: 'Live TV' },
     photo: { icon: Image, label: 'Photo' },
+    trailer: { icon: Clapperboard, label: 'Trailer' },
     unknown: { icon: CircleHelp, label: 'Unknown' },
   };
   const { icon: Icon, label } = config[type];

--- a/apps/web/src/components/history/SessionDetailSheet.tsx
+++ b/apps/web/src/components/history/SessionDetailSheet.tsx
@@ -35,6 +35,7 @@ import {
   Clock,
   ExternalLink,
   ChevronDown,
+  Clapperboard,
 } from 'lucide-react';
 import { cn, getCountryName, getMediaDisplay } from '@/lib/utils';
 import { getAvatarUrl } from '@/components/users/utils';
@@ -79,6 +80,7 @@ const MEDIA_CONFIG: Record<MediaType, { icon: typeof Film; label: string }> = {
   track: { icon: Music, label: 'Track' },
   live: { icon: Radio, label: 'Live TV' },
   photo: { icon: Image, label: 'Photo' },
+  trailer: { icon: Clapperboard, label: 'Trailer' },
   unknown: { icon: CircleHelp, label: 'Unknown' },
 };
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -144,7 +144,7 @@ export interface AuthUser {
 export type SessionState = 'playing' | 'paused' | 'stopped';
 
 /** Supported media types */
-export const MEDIA_TYPES = ['movie', 'episode', 'track', 'live', 'photo', 'unknown'] as const;
+export const MEDIA_TYPES = ['movie', 'episode', 'track', 'live', 'photo', 'trailer', 'unknown'] as const;
 export type MediaType = (typeof MEDIA_TYPES)[number];
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Adds support for detecting Plex trailer clips as "Trailer" media type instead of showing them as "Unknown".

When playing a Plex trailer (e.g., movie trailers, teaser clips), Tracearr now correctly displays them as "Trailer" 🎬 in session details instead of "Unknown" ❓.

## Changes
- Added `'trailer'` to supported media types in shared package
- Map Plex `'clip'` type to `'trailer'` in the Plex parser
- Added Clapperboard icon for trailers in web, mobile and history UIs
- Excluded trailers from primary statistics (like music tracks and photos)