### PR TITLE
Fix plex server count on update

### DIFF
--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { NavLink, Routes, Route, Link as RouterLink } from 'react-router';
 import { QRCodeSVG } from 'qrcode.react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -633,6 +634,7 @@ function ServerSettings() {
   const syncServer = useSyncServer();
   const updateServerUrl = useUpdateServerUrl();
   const reorderServers = useReorderServers();
+  const queryClient = useQueryClient();
   const { refetch: refetchUser, user } = useAuth();
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [showAddDialog, setShowAddDialog] = useState(false);
@@ -690,7 +692,7 @@ function ServerSettings() {
       deleteServer.mutate(deleteId, {
         onSuccess: () => {
           setDeleteId(null);
-          fetchPlexServers();
+          void queryClient.invalidateQueries({ queryKey: ['plex-accounts'] });
         },
       });
     }
@@ -818,9 +820,10 @@ function ServerSettings() {
 
       toast.success('Server Added', { description: `${name} has been connected successfully` });
 
-      // Refresh server list and user data
+      // Refresh server list, user data, and plex accounts (for server count)
       await refetch();
       await refetchUser();
+      void queryClient.invalidateQueries({ queryKey: ['plex-accounts'] });
 
       // Close dialog and reset
       setShowAddDialog(false);


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

This is a fix for the server count under the linked plex accounts section. Currently when a server is added/removed the server count do not update and require a full page refresh to show the correct number. This PR fix that problem.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

<!-- Link to issue if applicable. Features should have been discussed first in Discussions or Discord. -->

Closes #

## Changes

<!-- What specifically changed? -->

- Added `queryClient.invalidateQueries({ queryKey: ['plex-accounts'] })` to refresh server count in `handleDelete`
 and `handlePlexServerSelect`  in `Settings.tsx`

## Screenshots

<!-- For UI changes. Delete this section otherwise. -->

## Testing

- [ ] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [X] Tested manually

<!-- If manual testing, describe what you did: -->

I added and remove plex servers. The UI updated accordingly

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [X] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [X] Self-reviewed
- [X] No new warnings from `pnpm typecheck`
- [X] Tests pass locally
