### PR TITLE
Correctly count transcodes vs Direct Play/Stream (not transcodes)

### DIFF
--- a/apps/server/src/routes/stats/devices.ts
+++ b/apps/server/src/routes/stats/devices.ts
@@ -86,9 +86,9 @@ export const devicesRoutes: FastifyPluginAsync = async (app) => {
           video_decision,
           audio_decision,
           COUNT(*)::int AS session_count,
-          COUNT(*) FILTER (WHERE video_decision = 'directplay')::int AS video_direct_count,
-          COUNT(*) FILTER (WHERE audio_decision = 'directplay')::int AS audio_direct_count,
-          COUNT(*) FILTER (WHERE video_decision = 'directplay' AND audio_decision = 'directplay')::int AS full_direct_count,
+          COUNT(*) FILTER (WHERE video_decision != 'transcode')::int AS video_direct_count,
+          COUNT(*) FILTER (WHERE audio_decision != 'transcode')::int AS audio_direct_count,
+          COUNT(*) FILTER (WHERE video_decision != 'transcode' AND audio_decision != 'transcode')::int AS full_direct_count,
           COUNT(*) FILTER (WHERE video_decision = 'transcode' OR audio_decision = 'transcode')::int AS any_transcode_count
         FROM sessions
         ${baseWhere}
@@ -211,8 +211,8 @@ export const devicesRoutes: FastifyPluginAsync = async (app) => {
           COALESCE(platform, 'Unknown') AS device_type,
           COALESCE(source_video_codec, 'Unknown') AS video_codec,
           COUNT(*)::int AS session_count,
-          COUNT(*) FILTER (WHERE video_decision = 'directplay')::int AS direct_count,
-          ROUND(100.0 * COUNT(*) FILTER (WHERE video_decision = 'directplay') / NULLIF(COUNT(*), 0), 1) AS direct_pct
+          COUNT(*) FILTER (WHERE video_decision != 'transcode')::int AS direct_count,
+          ROUND(100.0 * COUNT(*) FILTER (WHERE video_decision != 'transcode') / NULLIF(COUNT(*), 0), 1) AS direct_pct
         FROM sessions
         ${baseWhere}
         AND source_video_codec IS NOT NULL
@@ -290,11 +290,11 @@ export const devicesRoutes: FastifyPluginAsync = async (app) => {
         SELECT
           COALESCE(platform, 'Unknown') AS device,
           COUNT(*)::int AS sessions,
-          COUNT(*) FILTER (WHERE video_decision = 'directplay')::int AS video_direct,
-          COUNT(*) FILTER (WHERE audio_decision = 'directplay')::int AS audio_direct,
-          COUNT(*) FILTER (WHERE video_decision = 'directplay' AND audio_decision = 'directplay')::int AS full_direct,
+          COUNT(*) FILTER (WHERE video_decision != 'transcode')::int AS video_direct,
+          COUNT(*) FILTER (WHERE audio_decision != 'transcode')::int AS audio_direct,
+          COUNT(*) FILTER (WHERE video_decision != 'transcode' AND audio_decision != 'transcode')::int AS full_direct,
           COUNT(*) FILTER (WHERE video_decision = 'transcode' OR audio_decision = 'transcode')::int AS transcode_count,
-          ROUND(100.0 * COUNT(*) FILTER (WHERE video_decision = 'directplay' AND audio_decision = 'directplay') / NULLIF(COUNT(*), 0), 1) AS direct_play_pct
+          ROUND(100.0 * COUNT(*) FILTER (WHERE video_decision != 'transcode' AND audio_decision != 'transcode') / NULLIF(COUNT(*), 0), 1) AS direct_play_pct
         FROM sessions
         ${baseWhere}
         AND source_video_codec IS NOT NULL
@@ -363,9 +363,9 @@ export const devicesRoutes: FastifyPluginAsync = async (app) => {
           COALESCE(source_video_codec, 'Unknown') AS video_codec,
           COALESCE(source_audio_codec, 'Unknown') AS audio_codec,
           COUNT(*)::int AS sessions,
-          COUNT(*) FILTER (WHERE video_decision = 'directplay' AND audio_decision = 'directplay')::int AS direct_count,
+          COUNT(*) FILTER (WHERE video_decision != 'transcode' AND audio_decision != 'transcode')::int AS direct_count,
           COUNT(*) FILTER (WHERE video_decision = 'transcode' OR audio_decision = 'transcode')::int AS transcode_count,
-          ROUND(100.0 * COUNT(*) FILTER (WHERE video_decision = 'directplay' AND audio_decision = 'directplay') / NULLIF(COUNT(*), 0), 1) AS direct_play_pct
+          ROUND(100.0 * COUNT(*) FILTER (WHERE video_decision != 'transcode' AND audio_decision != 'transcode') / NULLIF(COUNT(*), 0), 1) AS direct_play_pct
         FROM sessions
         ${baseWhere}
         AND source_video_codec IS NOT NULL
@@ -445,9 +445,9 @@ export const devicesRoutes: FastifyPluginAsync = async (app) => {
           u.name AS identity_name,
           su.thumb_url AS avatar,
           COUNT(*)::int AS total_sessions,
-          COUNT(*) FILTER (WHERE s.video_decision = 'directplay' AND s.audio_decision = 'directplay')::int AS direct_play_count,
+          COUNT(*) FILTER (WHERE s.video_decision != 'transcode' AND s.audio_decision != 'transcode')::int AS direct_play_count,
           COUNT(*) FILTER (WHERE s.video_decision = 'transcode' OR s.audio_decision = 'transcode')::int AS transcode_count,
-          ROUND(100.0 * COUNT(*) FILTER (WHERE s.video_decision = 'directplay' AND s.audio_decision = 'directplay') / NULLIF(COUNT(*), 0), 1) AS direct_play_pct
+          ROUND(100.0 * COUNT(*) FILTER (WHERE s.video_decision != 'transcode' AND s.audio_decision != 'transcode') / NULLIF(COUNT(*), 0), 1) AS direct_play_pct
         FROM sessions s
         JOIN server_users su ON s.server_user_id = su.id
         LEFT JOIN users u ON su.user_id = u.id


### PR DESCRIPTION
Fixes #305

## Summary

Fixes more counts of direct play vs transcodes in the Devices page.
Follow-up for d83fb91c67834be37b85c5308aec9ed99b7a0126

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

Closes #305

## Changes

Instead of counting rows where audio or video decision = `directplay`, we need to count rows where decision is not `transcode`. This will count `directplay` and `copy` (direct stream) decisions.

## Testing

- [ ] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [ ] Tested manually

<!-- If manual testing, describe what you did: -->

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
