### PR TITLE
wrap temp table queries in a transaction to avoid getting a new conne…

### DIFF
--- a/apps/server/src/jobs/maintenanceQueue.ts
+++ b/apps/server/src/jobs/maintenanceQueue.ts
@@ -1558,7 +1558,7 @@ async function processBackfillLibrarySnapshotsJob(
 
         // Wrap all temp table operations in a single transaction to ensure
         // the temp table is visible across all queries on the same connection
-        await db.transaction(async (tx: typeof db) => {
+        await db.transaction(async (tx) => {
           // PHASE 1: Pre-compute cumulative data ONCE for the entire library
           // Drop and recreate temp table for each library
           await tx.execute(sql`DROP TABLE IF EXISTS backfill_cumulative`);


### PR DESCRIPTION
…ction and losing it

## Summary

<!-- What does this PR do? -->

Fixes #319

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

<!-- Link to issue if applicable. Features should have been discussed first in Discussions or Discord. -->

Closes #319

## Changes

<!-- What specifically changed? -->

- for library backfille job: wraps temp table queries in a transaction, to ensure that a drizzle db.execute() does not get assigned a new connection ID

## Screenshots

<!-- For UI changes. Delete this section otherwise. -->

## Testing

- [ ] Added/updated unit tests
- [ ] Ran test suite locally (`pnpm test:unit`)
- [X] Tested manually

<!-- If manual testing, describe what you did: -->

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [ ] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [X] Self-reviewed
- [ ] No new warnings from `pnpm typecheck`
- [ ] Tests pass locally
