### PR TITLE
Handle QR generation failures more gracefully

### DIFF
--- a/apps/web/src/components/settings/MobileSettings.tsx
+++ b/apps/web/src/components/settings/MobileSettings.tsx
@@ -327,10 +327,16 @@ export function MobileSettings() {
           ) : (
             <>
               <div className="flex items-center justify-between">
-                <div>
+                <div className="space-y-1">
                   <p className="text-muted-foreground text-sm">
                     {deviceCount} of {maxDevices} devices connected
                   </p>
+                  {config.pendingTokens > 0 && (
+                    <p className="text-muted-foreground text-xs">
+                      {config.pendingTokens} pending token
+                      {config.pendingTokens !== 1 ? 's' : ''} awaiting pairing
+                    </p>
+                  )}
                 </div>
                 <Button
                   onClick={handleAddDevice}


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->
1. Attempt to catch and handle QR generation errors better.
2. Displays number of unpaired tokens on the mobile settings page

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [X] Refactor
- [ ] Breaking change

## Related Issue

<!-- Link to issue if applicable. Features should have been discussed first in Discussions or Discord. -->

support thread from discord

## Screenshots

<img width="405" height="321" alt="image" src="https://github.com/user-attachments/assets/0ac52a47-4b15-489a-a88f-18ac61c09bc7" />

## Testing

- [ ] Added/updated unit tests
- [X] Ran test suite locally (`pnpm test:unit`)
- [X] Tested manually

<!-- If manual testing, describe what you did: -->

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [X] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [X] Self-reviewed
- [X] No new warnings from `pnpm typecheck`
- [X] Tests pass locally
