### PR TITLE
24h time

### DIFF
--- a/apps/web/src/components/charts/ConcurrentChart.tsx
+++ b/apps/web/src/components/charts/ConcurrentChart.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
+import { getHour12 } from '@/lib/timeFormat';
 import { ChartSkeleton } from '@/components/ui/skeleton';
 
 interface ConcurrentData {
@@ -79,7 +80,7 @@ export function ConcurrentChart({
             }
             if (period === 'day') {
               // Hourly - show time only
-              return date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true });
+              return date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: getHour12() });
             }
             // week (6-hour) / month (daily): M/D format
             return `${date.getMonth() + 1}/${date.getDate()}`;
@@ -154,7 +155,7 @@ export function ConcurrentChart({
               });
             } else {
               // day (hourly) or week (6-hour) - show date and time
-              dateStr = `${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} ${date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })}`;
+              dateStr = `${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} ${date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: getHour12() })}`;
             }
           }
           let html = `<b>${dateStr}</b>`;

--- a/apps/web/src/components/charts/HourOfDayChart.tsx
+++ b/apps/web/src/components/charts/HourOfDayChart.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
+import { getHour12 } from '@/lib/timeFormat';
 import { ChartSkeleton } from '@/components/ui/skeleton';
 
 interface HourOfDayData {
@@ -20,8 +21,11 @@ export function HourOfDayChart({ data, isLoading, height = 250 }: HourOfDayChart
       return {};
     }
 
-    // Format hour labels (12am, 1am, ... 11pm)
+    // Format hour labels based on time format preference
     const formatHour = (hour: number): string => {
+      if (!getHour12()) {
+        return `${hour.toString().padStart(2, '0')}:00`;
+      }
       if (hour === 0) return '12am';
       if (hour === 12) return '12pm';
       return hour < 12 ? `${hour}am` : `${hour - 12}pm`;

--- a/apps/web/src/components/charts/HourlyDistributionChart.tsx
+++ b/apps/web/src/components/charts/HourlyDistributionChart.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import type { HourlyDistribution } from '@tracearr/shared';
+import { getHour12 } from '@/lib/timeFormat';
 import { ChartSkeleton } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/library';
 import { Clock } from 'lucide-react';
@@ -13,6 +14,9 @@ interface HourlyDistributionChartProps {
 }
 
 const formatHour = (hour: number): string => {
+  if (!getHour12()) {
+    return `${hour.toString().padStart(2, '0')}:00`;
+  }
   if (hour === 0) return '12am';
   if (hour === 12) return '12pm';
   return hour < 12 ? `${hour}am` : `${hour - 12}pm`;

--- a/apps/web/src/components/charts/PlaysChart.tsx
+++ b/apps/web/src/components/charts/PlaysChart.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import type { PlayStats } from '@tracearr/shared';
+import { getHour12 } from '@/lib/timeFormat';
 import { ChartSkeleton } from '@/components/ui/skeleton';
 
 interface PlaysChartProps {
@@ -57,7 +58,7 @@ export function PlaysChart({ data, isLoading, height = 200, period = 'month' }: 
             }
             if (period === 'day') {
               // Hourly - show time only
-              return date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true });
+              return date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: getHour12() });
             }
             // week (6-hour) / month (daily): M/D format
             return `${date.getMonth() + 1}/${date.getDate()}`;
@@ -136,7 +137,7 @@ export function PlaysChart({ data, isLoading, height = 200, period = 'month' }: 
               });
             } else {
               // day (hourly) or week (6-hour) - show date and time
-              dateStr = `${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} ${date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })}`;
+              dateStr = `${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} ${date.toLocaleTimeString('en-US', { hour: 'numeric', hour12: getHour12() })}`;
             }
           }
           return `<b>${dateStr}</b><br/>Plays: ${this.y}`;

--- a/apps/web/src/components/history/HistoryTable.tsx
+++ b/apps/web/src/components/history/HistoryTable.tsx
@@ -44,6 +44,7 @@ import { getAvatarUrl } from '@/components/users/utils';
 import type { SessionWithDetails, SessionState, MediaType, EngagementTier } from '@tracearr/shared';
 import type { ColumnVisibility } from './HistoryFilters';
 import { format } from 'date-fns';
+import { getTimeFormatString } from '@/lib/timeFormat';
 
 // Engagement tier config
 const ENGAGEMENT_TIER_CONFIG: Record<
@@ -243,7 +244,7 @@ export const HistoryTableRow = forwardRef<
                 {format(new Date(session.startedAt), 'MMM d, yyyy')}
               </div>
               <div className="text-muted-foreground text-xs">
-                {format(new Date(session.startedAt), 'h:mm a')}
+                {format(new Date(session.startedAt), getTimeFormatString())}
               </div>
             </div>
           </div>

--- a/apps/web/src/components/history/SessionDetailSheet.tsx
+++ b/apps/web/src/components/history/SessionDetailSheet.tsx
@@ -52,6 +52,7 @@ import type {
   ServerType,
 } from '@tracearr/shared';
 import { format, formatDistanceToNow } from 'date-fns';
+import { getDateTimeFormatString } from '@/lib/timeFormat';
 
 // Accept both SessionWithDetails (history) and ActiveSession (now playing)
 // Both types have the same nested user/server structure
@@ -333,7 +334,7 @@ export function SessionDetailSheet({ session, open, onOpenChange }: Props) {
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">Started</span>
                 <span>
-                  {format(new Date(session.startedAt), 'MMM d, h:mm a')}
+                  {format(new Date(session.startedAt), getDateTimeFormatString())}
                   <span className="text-muted-foreground ml-1.5 text-xs">
                     ({formatDistanceToNow(new Date(session.startedAt), { addSuffix: true })})
                   </span>
@@ -342,7 +343,7 @@ export function SessionDetailSheet({ session, open, onOpenChange }: Props) {
               {session.stoppedAt && (
                 <div className="flex items-center justify-between">
                   <span className="text-muted-foreground">Stopped</span>
-                  <span>{format(new Date(session.stoppedAt), 'MMM d, h:mm a')}</span>
+                  <span>{format(new Date(session.stoppedAt), getDateTimeFormatString())}</span>
                 </div>
               )}
               <div className="flex items-center justify-between">

--- a/apps/web/src/components/settings/GeneralSettings.tsx
+++ b/apps/web/src/components/settings/GeneralSettings.tsx
@@ -39,6 +39,7 @@ import {
   Palette,
   Settings as SettingsIcon,
   Languages,
+  Clock,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
@@ -51,6 +52,7 @@ import {
   changeLanguage,
   useTranslation,
 } from '@tracearr/translations';
+import { getTimeFormat, setTimeFormat, type TimeFormat } from '@/lib/timeFormat';
 
 type ThemeMode = 'light' | 'dark' | 'system';
 
@@ -219,6 +221,39 @@ function LanguageField() {
           <ExternalLink className="h-3 w-3" />
         </a>
       </FieldDescription>
+    </Field>
+  );
+}
+
+/**
+ * Time format selector field with localStorage persistence.
+ */
+function TimeFormatField() {
+  const { t } = useTranslation('settings');
+  const [timeFormat, setTimeFormatState] = useState<TimeFormat>(getTimeFormat);
+
+  const handleTimeFormatChange = (value: string) => {
+    const tf = value as TimeFormat;
+    setTimeFormatState(tf);
+    setTimeFormat(tf);
+  };
+
+  return (
+    <Field>
+      <FieldLabel htmlFor="timeFormat" className="flex items-center gap-2">
+        <Clock className="h-4 w-4" />
+        {t('general.timeFormat')}
+      </FieldLabel>
+      <Select value={timeFormat} onValueChange={handleTimeFormatChange}>
+        <SelectTrigger id="timeFormat" className="w-full max-w-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="12h">{t('general.timeFormat12h')}</SelectItem>
+          <SelectItem value="24h">{t('general.timeFormat24h')}</SelectItem>
+        </SelectContent>
+      </Select>
+      <FieldDescription>{t('general.timeFormatDescription')}</FieldDescription>
     </Field>
   );
 }
@@ -415,6 +450,8 @@ export function GeneralSettings() {
             />
 
             <LanguageField />
+
+            <TimeFormatField />
 
             <AutosaveSwitchField
               id="pollerEnabled"

--- a/apps/web/src/lib/formatters.ts
+++ b/apps/web/src/lib/formatters.ts
@@ -3,6 +3,7 @@
  * Centralizes duplicated logic from multiple components.
  */
 import { formatDistanceToNow, format } from 'date-fns';
+import { getTimeFormatString, getDateTimeFormatString } from '@/lib/timeFormat';
 
 /**
  * Safely parse a date that might be a Date object, string, null, or undefined.
@@ -167,7 +168,7 @@ export function formatListTimestamp(date: Date | string | null | undefined): str
   yesterday.setDate(yesterday.getDate() - 1);
 
   const dateOnly = new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
-  const timeStr = format(parsed, 'h:mm a');
+  const timeStr = format(parsed, getTimeFormatString());
 
   if (dateOnly.getTime() === today.getTime()) {
     return `Today ${timeStr}`;
@@ -175,7 +176,7 @@ export function formatListTimestamp(date: Date | string | null | undefined): str
   if (dateOnly.getTime() === yesterday.getTime()) {
     return `Yesterday ${timeStr}`;
   }
-  return format(parsed, 'MMM d, h:mm a');
+  return format(parsed, getDateTimeFormatString());
 }
 
 /**

--- a/apps/web/src/lib/timeFormat.ts
+++ b/apps/web/src/lib/timeFormat.ts
@@ -1,0 +1,67 @@
+/**
+ * Time format preference management (12-hour vs 24-hour).
+ * Stored in localStorage.
+ */
+
+const TIME_FORMAT_STORAGE_KEY = 'tracearr_time_format';
+
+export type TimeFormat = '12h' | '24h';
+
+/**
+ * Get the current time format preference.
+ * Returns '12h' if no preference is stored.
+ */
+export function getTimeFormat(): TimeFormat {
+  try {
+    const stored = localStorage.getItem(TIME_FORMAT_STORAGE_KEY);
+    if (stored === '12h' || stored === '24h') return stored;
+  } catch {
+    // Fails in private browsing or when storage is disabled
+  }
+  return '12h';
+}
+
+/**
+ * Set the time format preference and persist it.
+ */
+export function setTimeFormat(format: TimeFormat): void {
+  try {
+    localStorage.setItem(TIME_FORMAT_STORAGE_KEY, format);
+  } catch {
+    // Fails in private browsing or when quota exceeded
+  }
+}
+
+/**
+ * Get the date-fns format string for time only.
+ * 12h: 'h:mm a' (e.g., "3:30 PM")
+ * 24h: 'H:mm' (e.g., "15:30")
+ */
+export function getTimeFormatString(): 'h:mm a' | 'H:mm' {
+  return getTimeFormat() === '24h' ? 'H:mm' : 'h:mm a';
+}
+
+/**
+ * Get the date-fns format string for date + time.
+ * 12h: 'MMM d, h:mm a' (e.g., "Jan 2, 3:30 PM")
+ * 24h: 'MMM d, H:mm' (e.g., "Jan 2, 15:30")
+ */
+export function getDateTimeFormatString(): 'MMM d, h:mm a' | 'MMM d, H:mm' {
+  return getTimeFormat() === '24h' ? 'MMM d, H:mm' : 'MMM d, h:mm a';
+}
+
+/**
+ * Get the date-fns format string for full date + time with seconds.
+ * 12h: 'MMM d, yyyy, h:mm:ss a' (e.g., "Feb 13, 2026, 3:30:45 PM")
+ * 24h: 'MMM d, yyyy, H:mm:ss' (e.g., "Feb 13, 2026, 15:30:45")
+ */
+export function getFullDateTimeFormatString(): string {
+  return getTimeFormat() === '24h' ? 'MMM d, yyyy, H:mm:ss' : 'MMM d, yyyy, h:mm:ss a';
+}
+
+/**
+ * Get the hour12 boolean for Intl.DateTimeFormat / toLocaleTimeString.
+ */
+export function getHour12(): boolean {
+  return getTimeFormat() !== '24h';
+}

--- a/apps/web/src/pages/ViolationDetail.tsx
+++ b/apps/web/src/pages/ViolationDetail.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, lazy, Suspense } from 'react';
 import { useParams, Link, useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { formatDistanceToNow, format } from 'date-fns';
+import { getFullDateTimeFormatString } from '@/lib/timeFormat';
 import type { ColumnDef } from '@tanstack/react-table';
 import type {
   ViolationSessionInfo,
@@ -630,7 +631,10 @@ export function ViolationDetail() {
                 ) : violation.data.lastActivityAt ? (
                   <div>
                     <p className="font-medium">
-                      {format(new Date(violation.data.lastActivityAt as string), 'PPpp')}
+                      {format(
+                        new Date(violation.data.lastActivityAt as string),
+                        getFullDateTimeFormatString()
+                      )}
                     </p>
                     <p className="text-muted-foreground text-xs">
                       {formatDistanceToNow(new Date(violation.data.lastActivityAt as string), {
@@ -670,7 +674,9 @@ export function ViolationDetail() {
               <p className="text-muted-foreground mb-1 text-xs">
                 {t('pages:violations.detail.created')}
               </p>
-              <p className="text-sm font-medium">{format(new Date(violation.createdAt), 'PPpp')}</p>
+              <p className="text-sm font-medium">
+                {format(new Date(violation.createdAt), getFullDateTimeFormatString())}
+              </p>
               <p className="text-muted-foreground text-xs">
                 {formatDistanceToNow(new Date(violation.createdAt), { addSuffix: true })}
               </p>
@@ -681,7 +687,7 @@ export function ViolationDetail() {
                   {t('pages:violations.detail.acknowledged')}
                 </p>
                 <p className="text-sm font-medium">
-                  {format(new Date(violation.acknowledgedAt), 'PPpp')}
+                  {format(new Date(violation.acknowledgedAt), getFullDateTimeFormatString())}
                 </p>
                 <p className="text-muted-foreground text-xs">
                   {formatDistanceToNow(new Date(violation.acknowledgedAt), { addSuffix: true })}

--- a/apps/web/src/pages/library/Overview.tsx
+++ b/apps/web/src/pages/library/Overview.tsx
@@ -11,6 +11,7 @@ import { useLibraryStats, useLibraryGrowth, useLibraryStatus } from '@/hooks/que
 import { useServer } from '@/hooks/useServer';
 import { useTimeRange } from '@/hooks/useTimeRange';
 import { formatBytes } from '@/lib/formatters';
+import { getHour12 } from '@/lib/timeFormat';
 
 /**
  * Format date for last updated display
@@ -24,6 +25,7 @@ function formatLastUpdated(dateStr: string | null | undefined): string {
     year: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
+    hour12: getHour12(),
   });
 }
 

--- a/apps/web/src/pages/library/Watch.tsx
+++ b/apps/web/src/pages/library/Watch.tsx
@@ -15,9 +15,13 @@ import {
 } from '@/components/charts';
 import { useLibraryWatch, useLibraryCompletion, useLibraryPatterns } from '@/hooks/queries';
 import { useServer } from '@/hooks/useServer';
+import { getHour12 } from '@/lib/timeFormat';
 
 function formatPeakHour(hour: number | undefined): string {
   if (hour === undefined) return '-';
+  if (!getHour12()) {
+    return `${hour.toString().padStart(2, '0')}:00`;
+  }
   if (hour === 0) return '12 AM';
   if (hour === 12) return '12 PM';
   return hour < 12 ? `${hour} AM` : `${hour - 12} PM`;

--- a/packages/translations/src/locales/_template/settings.json
+++ b/packages/translations/src/locales/_template/settings.json
@@ -16,7 +16,11 @@
     "primaryAuth": "Primary Authentication Method",
     "localAccount": "Local Account",
     "plexAccount": "Plex Account",
-    "jellyfinAccount": "Jellyfin Account"
+    "jellyfinAccount": "Jellyfin Account",
+    "timeFormat": "Time Format",
+    "timeFormatDescription": "Choose how times are displayed.",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)"
   },
   "servers": {
     "title": "Connected Servers",

--- a/packages/translations/src/locales/af/settings.json
+++ b/packages/translations/src/locales/af/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/ar/settings.json
+++ b/packages/translations/src/locales/ar/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/ca/settings.json
+++ b/packages/translations/src/locales/ca/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/cs/settings.json
+++ b/packages/translations/src/locales/cs/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/da/settings.json
+++ b/packages/translations/src/locales/da/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/de/settings.json
+++ b/packages/translations/src/locales/de/settings.json
@@ -1,120 +1,124 @@
 {
-  "tabs": {
-    "general": "Allgemein",
-    "servers": "Server",
-    "notifications": "Benachrichtigungen",
-    "mobile": "Mobile App",
-    "import": "Importieren",
-    "advanced": "Erweitert",
-    "jobs": "Jobs",
-    "accessControl": "Zugangs kontrolle"
+  "account": {
+    "createAccount": "Konto erstellen",
+    "createYourAccount": "Konto erstellen, um zu beginnen",
+    "displayName": "Anzeigename",
+    "email": "E-Mail",
+    "password": "Passwort",
+    "signIn": "Anmelden",
+    "signInToAccount": "Bei Konto anmelden",
+    "useJellyfinAccount": "Stattdessen Jellyfin-Konto verwenden",
+    "useLocalAccount": "Stattdessen lokales Konto verwenden",
+    "waitingForPlex": "Auf Plex-Autorisierung warten..."
+  },
+  "advanced": {
+    "basePath": "Basispfad",
+    "connectionScenarios": "Verbindungsszenarien",
+    "externalUrl": "Externe URL",
+    "reverseProxy": "Reverse Proxy",
+    "title": "Erweiterte Einstellungen",
+    "trustProxy": "Proxy-Header vertrauen"
   },
   "general": {
-    "title": "Allgemeine Einstellungen",
-    "unitSystem": "Einheitensystem",
-    "metric": "Metrisch (km, km/h)",
+    "helpTranslate": "Hilf bei der Übersetzung von Tracearr",
     "imperial": "Imperial (mi, mph)",
-    "timezone": "Zeitzone",
-    "primaryAuth": "Primäre Authentifizierungsmethode",
-    "localAccount": "Lokales Konto",
-    "plexAccount": "Plex-Konto",
     "jellyfinAccount": "Jellyfin-Konto",
     "language": "Sprache",
     "languageDescription": "Wählen Sie Ihre bevorzugte Anzeigesprache.",
-    "helpTranslate": "Hilf bei der Übersetzung von Tracearr"
-  },
-  "servers": {
-    "title": "Verbundene Server",
-    "addServer": "Server hinzufügen",
-    "serverName": "Servername",
-    "serverUrl": "Server-URL",
-    "apiKey": "API Key",
-    "syncInterval": "Synchronisierungsintervall",
-    "testConnection": "Verbindung testen",
-    "connectionSuccess": "Verbindung erfolgreich",
-    "connectionFailed": "Verbindung fehlgeschlagen"
-  },
-  "mobile": {
-    "title": "Mobile App",
-    "pairDevice": "Gerät koppeln",
-    "connectedDevices": "Verbundene Geräte",
-    "generateToken": "Pairing-Token generieren",
-    "scanQrCode": "QR-Code scannen",
-    "tokenExpires": "Token läuft in {{time}} ab",
-    "noDevices": "Keine Geräte verbunden",
-    "revokeAll": "Alle Sitzungen widerrufen"
-  },
-  "webhooks": {
-    "title": "Webhook-Konfiguration",
-    "discordWebhook": "Discord Webhook-URL",
-    "ntfyTopic": "Ntfy Topic",
-    "customWebhook": "Benutzerdefinierte Webhook-URL",
-    "webhookFormat": "Webhook-Format",
-    "testWebhook": "Webhook testen"
-  },
-  "advanced": {
-    "title": "Erweiterte Einstellungen",
-    "basePath": "Basispfad",
-    "externalUrl": "Externe URL",
-    "trustProxy": "Proxy-Header vertrauen",
-    "reverseProxy": "Reverse Proxy",
-    "connectionScenarios": "Verbindungsszenarien"
+    "localAccount": "Lokales Konto",
+    "metric": "Metrisch (km, km/h)",
+    "plexAccount": "Plex-Konto",
+    "primaryAuth": "Primäre Authentifizierungsmethode",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
+    "timezone": "Zeitzone",
+    "title": "Allgemeine Einstellungen",
+    "unitSystem": "Einheitensystem"
   },
   "import": {
-    "title": "Daten importieren",
-    "jellystat": "Aus Jellystat importieren",
-    "tautulli": "Aus Tautulli importieren",
-    "importProgress": "Importfortschritt",
+    "enriched": "Angereichert",
+    "errors": "Fehler",
     "importComplete": "Import abgeschlossen",
     "importFailed": "Import fehlgeschlagen",
-    "processed": "Verarbeitet",
-    "page": "Seite",
+    "importProgress": "Importfortschritt",
     "imported": "Importiert",
+    "jellystat": "Aus Jellystat importieren",
+    "page": "Seite",
+    "processed": "Verarbeitet",
     "skipped": "Übersprungen",
-    "enriched": "Angereichert",
-    "errors": "Fehler"
-  },
-  "plex": {
-    "linkedAccounts": "Verknüpfte Plex-Konten",
-    "unlinkAccount": "Plex-Konto trennen",
-    "signInWithPlex": "Mit Plex anmelden",
-    "signUpWithPlex": "Mit Plex registrieren",
-    "selectServer": "Server auswählen",
-    "chooseServer": "Wähle aus, welcher Plex Media Server überwacht werden soll"
-  },
-  "jellyfin": {
-    "signInWithJellyfin": "Mit Jellyfin anmelden",
-    "username": "Jellyfin-Benutzername",
-    "password": "Jellyfin-Passwort"
-  },
-  "account": {
-    "createAccount": "Konto erstellen",
-    "signIn": "Anmelden",
-    "email": "E-Mail",
-    "password": "Passwort",
-    "displayName": "Anzeigename",
-    "createYourAccount": "Konto erstellen, um zu beginnen",
-    "signInToAccount": "Bei Konto anmelden",
-    "useLocalAccount": "Stattdessen lokales Konto verwenden",
-    "useJellyfinAccount": "Stattdessen Jellyfin-Konto verwenden",
-    "waitingForPlex": "Auf Plex-Autorisierung warten..."
-  },
-  "update": {
-    "title": "Update verfügbar",
-    "releaseNotes": "Release Notes",
-    "updateCommand": "Befehl aktualisieren",
-    "pullInstructions": "Starten Sie nach dem laden Ihren Container neu, um das Update anzuwenden.",
-    "stableRelease": "Stable Release",
-    "betaUpdate": "Beta Update",
-    "newVersion": "Neue Version",
-    "versionAvailable": "{{version}} verfügabr"
-  },
-  "serverHealth": {
-    "unreachable": "{{serverName}} ist unerreichbar",
-    "multipleUnreachable": "{{count}} Server nicht erreichbar {{serverNames}}"
+    "tautulli": "Aus Tautulli importieren",
+    "title": "Daten importieren"
   },
   "ipWarning": {
-    "message": "Alle Benutzer scheinen dieselbe IP-Adresse oder dieselben lokalen Netzwerk-IPs zu verwenden. Dies kann Auswirkungen auf die regelbasierte Logik für Standort oder IP-Adressen haben.",
-    "acknowledge": "Verstanden"
+    "acknowledge": "Verstanden",
+    "message": "Alle Benutzer scheinen dieselbe IP-Adresse oder dieselben lokalen Netzwerk-IPs zu verwenden. Dies kann Auswirkungen auf die regelbasierte Logik für Standort oder IP-Adressen haben."
+  },
+  "jellyfin": {
+    "password": "Jellyfin-Passwort",
+    "signInWithJellyfin": "Mit Jellyfin anmelden",
+    "username": "Jellyfin-Benutzername"
+  },
+  "mobile": {
+    "connectedDevices": "Verbundene Geräte",
+    "generateToken": "Pairing-Token generieren",
+    "noDevices": "Keine Geräte verbunden",
+    "pairDevice": "Gerät koppeln",
+    "revokeAll": "Alle Sitzungen widerrufen",
+    "scanQrCode": "QR-Code scannen",
+    "title": "Mobile App",
+    "tokenExpires": "Token läuft in {{time}} ab"
+  },
+  "plex": {
+    "chooseServer": "Wähle aus, welcher Plex Media Server überwacht werden soll",
+    "linkedAccounts": "Verknüpfte Plex-Konten",
+    "selectServer": "Server auswählen",
+    "signInWithPlex": "Mit Plex anmelden",
+    "signUpWithPlex": "Mit Plex registrieren",
+    "unlinkAccount": "Plex-Konto trennen"
+  },
+  "serverHealth": {
+    "multipleUnreachable": "{{count}} Server nicht erreichbar {{serverNames}}",
+    "unreachable": "{{serverName}} ist unerreichbar"
+  },
+  "servers": {
+    "addServer": "Server hinzufügen",
+    "apiKey": "API Key",
+    "connectionFailed": "Verbindung fehlgeschlagen",
+    "connectionSuccess": "Verbindung erfolgreich",
+    "serverName": "Servername",
+    "serverUrl": "Server-URL",
+    "syncInterval": "Synchronisierungsintervall",
+    "testConnection": "Verbindung testen",
+    "title": "Verbundene Server"
+  },
+  "tabs": {
+    "accessControl": "Zugangs kontrolle",
+    "advanced": "Erweitert",
+    "general": "Allgemein",
+    "import": "Importieren",
+    "jobs": "Jobs",
+    "mobile": "Mobile App",
+    "notifications": "Benachrichtigungen",
+    "servers": "Server"
+  },
+  "update": {
+    "betaUpdate": "Beta Update",
+    "newVersion": "Neue Version",
+    "pullInstructions": "Starten Sie nach dem laden Ihren Container neu, um das Update anzuwenden.",
+    "releaseNotes": "Release Notes",
+    "stableRelease": "Stable Release",
+    "title": "Update verfügbar",
+    "updateCommand": "Befehl aktualisieren",
+    "versionAvailable": "{{version}} verfügabr"
+  },
+  "webhooks": {
+    "customWebhook": "Benutzerdefinierte Webhook-URL",
+    "discordWebhook": "Discord Webhook-URL",
+    "ntfyTopic": "Ntfy Topic",
+    "testWebhook": "Webhook testen",
+    "title": "Webhook-Konfiguration",
+    "webhookFormat": "Webhook-Format"
   }
 }

--- a/packages/translations/src/locales/el/settings.json
+++ b/packages/translations/src/locales/el/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/en/settings.json
+++ b/packages/translations/src/locales/en/settings.json
@@ -21,7 +21,11 @@
     "jellyfinAccount": "Jellyfin Account",
     "language": "Language",
     "languageDescription": "Choose your preferred display language.",
-    "helpTranslate": "Help translate Tracearr"
+    "helpTranslate": "Help translate Tracearr",
+    "timeFormat": "Time Format",
+    "timeFormatDescription": "Choose how times are displayed.",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)"
   },
   "servers": {
     "title": "Connected Servers",

--- a/packages/translations/src/locales/es/settings.json
+++ b/packages/translations/src/locales/es/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/fi/settings.json
+++ b/packages/translations/src/locales/fi/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/fr/settings.json
+++ b/packages/translations/src/locales/fr/settings.json
@@ -29,6 +29,10 @@
     "metric": "Métrique (km, km/h)",
     "plexAccount": "Compte Plex",
     "primaryAuth": "Méthode d'authentification principale",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Fuseau horaire",
     "title": "Réglages généraux",
     "unitSystem": "Système d'unité"

--- a/packages/translations/src/locales/he/settings.json
+++ b/packages/translations/src/locales/he/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/hu/settings.json
+++ b/packages/translations/src/locales/hu/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/it/settings.json
+++ b/packages/translations/src/locales/it/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/ja/settings.json
+++ b/packages/translations/src/locales/ja/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/ko/settings.json
+++ b/packages/translations/src/locales/ko/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/nl/settings.json
+++ b/packages/translations/src/locales/nl/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/no/settings.json
+++ b/packages/translations/src/locales/no/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/pl/settings.json
+++ b/packages/translations/src/locales/pl/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/pt/settings.json
+++ b/packages/translations/src/locales/pt/settings.json
@@ -1,120 +1,124 @@
 {
-  "tabs": {
-    "general": "Geral",
-    "servers": "Servidores",
-    "notifications": "Notificações",
-    "mobile": "Aplicação móvel",
-    "import": "Importar",
-    "advanced": "Avançadas",
-    "jobs": "Jobs",
-    "accessControl": "Access Control"
+  "account": {
+    "createAccount": "Criar conta",
+    "createYourAccount": "Crie a sua conta para começar",
+    "displayName": "Nome para exibição",
+    "email": "E-mail",
+    "password": "Palavra-passe",
+    "signIn": "Iniciar sessão",
+    "signInToAccount": "Inicie sessão na sua conta",
+    "useJellyfinAccount": "Utilize a conta Jellyfin em vez disso",
+    "useLocalAccount": "Utilize a conta local em vez disso",
+    "waitingForPlex": "A aguardar autorização do Plex..."
+  },
+  "advanced": {
+    "basePath": "Diretório base",
+    "connectionScenarios": "Cenários de ligação",
+    "externalUrl": "URL externo",
+    "reverseProxy": "Proxy reverso",
+    "title": "Definições avançadas",
+    "trustProxy": "Confiar nos headers do proxy"
   },
   "general": {
-    "title": "Definições gerais",
-    "unitSystem": "Sistema de unidades",
-    "metric": "Métrico (km, km/h)",
+    "helpTranslate": "Ajude a traduzir o Tracearr",
     "imperial": "Imperial (mi, mph)",
-    "timezone": "Fuso horário",
-    "primaryAuth": "Método de autenticação principal",
-    "localAccount": "Conta local",
-    "plexAccount": "Conta Plex",
     "jellyfinAccount": "Conta Jellyfin",
     "language": "Idioma",
     "languageDescription": "Escolha o seu idioma de apresentação preferido.",
-    "helpTranslate": "Ajude a traduzir o Tracearr"
-  },
-  "servers": {
-    "title": "Servidores ligados",
-    "addServer": "Adicionar servidor",
-    "serverName": "Nome do servidor",
-    "serverUrl": "URL do servidor",
-    "apiKey": "Chave API",
-    "syncInterval": "Intervalo de sincronização",
-    "testConnection": "Testar ligação",
-    "connectionSuccess": "Ligação bem-sucedida",
-    "connectionFailed": "Falha na ligação"
-  },
-  "mobile": {
-    "title": "Aplicação móvel",
-    "pairDevice": "Emparelhar dispositivo",
-    "connectedDevices": "Dispositivos ligados",
-    "generateToken": "Gerar token de emparelhamento",
-    "scanQrCode": "Digitalizar código QR",
-    "tokenExpires": "O token expira em {{time}}",
-    "noDevices": "Sem dispositivos ligados",
-    "revokeAll": "Revogar todas as sessões"
-  },
-  "webhooks": {
-    "title": "Configuração do webhook",
-    "discordWebhook": "URL do webhook do Discord",
-    "ntfyTopic": "Tópico Ntfy",
-    "customWebhook": "URL do webhook personalizado",
-    "webhookFormat": "Formato do webhook",
-    "testWebhook": "Testar webhook"
-  },
-  "advanced": {
-    "title": "Definições avançadas",
-    "basePath": "Diretório base",
-    "externalUrl": "URL externo",
-    "trustProxy": "Confiar nos headers do proxy",
-    "reverseProxy": "Proxy reverso",
-    "connectionScenarios": "Cenários de ligação"
+    "localAccount": "Conta local",
+    "metric": "Métrico (km, km/h)",
+    "plexAccount": "Conta Plex",
+    "primaryAuth": "Método de autenticação principal",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
+    "timezone": "Fuso horário",
+    "title": "Definições gerais",
+    "unitSystem": "Sistema de unidades"
   },
   "import": {
-    "title": "Importar dados",
-    "jellystat": "Importar do Jellystat",
-    "tautulli": "Importar do Tautulli",
-    "importProgress": "Progresso da importação",
+    "enriched": "Enriched",
+    "errors": "Errors",
     "importComplete": "Importação concluída",
     "importFailed": "Falha na importação",
-    "processed": "Processed",
-    "page": "Page",
+    "importProgress": "Progresso da importação",
     "imported": "Imported",
+    "jellystat": "Importar do Jellystat",
+    "page": "Page",
+    "processed": "Processed",
     "skipped": "Skipped",
-    "enriched": "Enriched",
-    "errors": "Errors"
-  },
-  "plex": {
-    "linkedAccounts": "Contas Plex ligadas",
-    "unlinkAccount": "Desvincular conta Plex",
-    "signInWithPlex": "Iniciar sessão com o Plex",
-    "signUpWithPlex": "Registar-se com o Plex",
-    "selectServer": "Selecionar servidor",
-    "chooseServer": "Escolha o servidor Plex que pretende monitorizar"
-  },
-  "jellyfin": {
-    "signInWithJellyfin": "Iniciar sessão com o Jellyfin",
-    "username": "Nome de utilizador Jellyfin",
-    "password": "Palavra-passe Jellyfin"
-  },
-  "account": {
-    "createAccount": "Criar conta",
-    "signIn": "Iniciar sessão",
-    "email": "E-mail",
-    "password": "Palavra-passe",
-    "displayName": "Nome para exibição",
-    "createYourAccount": "Crie a sua conta para começar",
-    "signInToAccount": "Inicie sessão na sua conta",
-    "useLocalAccount": "Utilize a conta local em vez disso",
-    "useJellyfinAccount": "Utilize a conta Jellyfin em vez disso",
-    "waitingForPlex": "A aguardar autorização do Plex..."
-  },
-  "update": {
-    "title": "Update Available",
-    "releaseNotes": "Release Notes",
-    "updateCommand": "Update Command",
-    "pullInstructions": "After pulling, restart your container to apply the update.",
-    "stableRelease": "Stable Release",
-    "betaUpdate": "Beta Update",
-    "newVersion": "New Version",
-    "versionAvailable": "{{version}} available"
-  },
-  "serverHealth": {
-    "unreachable": "{{serverName}} is unreachable",
-    "multipleUnreachable": "{{count}} servers unreachable: {{serverNames}}"
+    "tautulli": "Importar do Tautulli",
+    "title": "Importar dados"
   },
   "ipWarning": {
-    "message": "All users appear to be using the same IP address or local network IPs. This may affect rule-based logic for location or IP addresses.",
-    "acknowledge": "Got it"
+    "acknowledge": "Got it",
+    "message": "All users appear to be using the same IP address or local network IPs. This may affect rule-based logic for location or IP addresses."
+  },
+  "jellyfin": {
+    "password": "Palavra-passe Jellyfin",
+    "signInWithJellyfin": "Iniciar sessão com o Jellyfin",
+    "username": "Nome de utilizador Jellyfin"
+  },
+  "mobile": {
+    "connectedDevices": "Dispositivos ligados",
+    "generateToken": "Gerar token de emparelhamento",
+    "noDevices": "Sem dispositivos ligados",
+    "pairDevice": "Emparelhar dispositivo",
+    "revokeAll": "Revogar todas as sessões",
+    "scanQrCode": "Digitalizar código QR",
+    "title": "Aplicação móvel",
+    "tokenExpires": "O token expira em {{time}}"
+  },
+  "plex": {
+    "chooseServer": "Escolha o servidor Plex que pretende monitorizar",
+    "linkedAccounts": "Contas Plex ligadas",
+    "selectServer": "Selecionar servidor",
+    "signInWithPlex": "Iniciar sessão com o Plex",
+    "signUpWithPlex": "Registar-se com o Plex",
+    "unlinkAccount": "Desvincular conta Plex"
+  },
+  "serverHealth": {
+    "multipleUnreachable": "{{count}} servers unreachable: {{serverNames}}",
+    "unreachable": "{{serverName}} is unreachable"
+  },
+  "servers": {
+    "addServer": "Adicionar servidor",
+    "apiKey": "Chave API",
+    "connectionFailed": "Falha na ligação",
+    "connectionSuccess": "Ligação bem-sucedida",
+    "serverName": "Nome do servidor",
+    "serverUrl": "URL do servidor",
+    "syncInterval": "Intervalo de sincronização",
+    "testConnection": "Testar ligação",
+    "title": "Servidores ligados"
+  },
+  "tabs": {
+    "accessControl": "Access Control",
+    "advanced": "Avançadas",
+    "general": "Geral",
+    "import": "Importar",
+    "jobs": "Jobs",
+    "mobile": "Aplicação móvel",
+    "notifications": "Notificações",
+    "servers": "Servidores"
+  },
+  "update": {
+    "betaUpdate": "Beta Update",
+    "newVersion": "New Version",
+    "pullInstructions": "After pulling, restart your container to apply the update.",
+    "releaseNotes": "Release Notes",
+    "stableRelease": "Stable Release",
+    "title": "Update Available",
+    "updateCommand": "Update Command",
+    "versionAvailable": "{{version}} available"
+  },
+  "webhooks": {
+    "customWebhook": "URL do webhook personalizado",
+    "discordWebhook": "URL do webhook do Discord",
+    "ntfyTopic": "Tópico Ntfy",
+    "testWebhook": "Testar webhook",
+    "title": "Configuração do webhook",
+    "webhookFormat": "Formato do webhook"
   }
 }

--- a/packages/translations/src/locales/ro/settings.json
+++ b/packages/translations/src/locales/ro/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/ru/settings.json
+++ b/packages/translations/src/locales/ru/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/sr/settings.json
+++ b/packages/translations/src/locales/sr/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/sv/settings.json
+++ b/packages/translations/src/locales/sv/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/tr/settings.json
+++ b/packages/translations/src/locales/tr/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/uk/settings.json
+++ b/packages/translations/src/locales/uk/settings.json
@@ -29,6 +29,10 @@
     "metric": "Метрична (км, км/год)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "Загальні налаштування",
     "unitSystem": "Система одиниць"

--- a/packages/translations/src/locales/vi/settings.json
+++ b/packages/translations/src/locales/vi/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"

--- a/packages/translations/src/locales/zh/settings.json
+++ b/packages/translations/src/locales/zh/settings.json
@@ -29,6 +29,10 @@
     "metric": "Metric (km, km/h)",
     "plexAccount": "Plex Account",
     "primaryAuth": "Primary Authentication Method",
+    "timeFormat": "Time Format",
+    "timeFormat12h": "12-hour (1:30 PM)",
+    "timeFormat24h": "24-hour (13:30)",
+    "timeFormatDescription": "Choose how times are displayed.",
     "timezone": "Timezone",
     "title": "General Settings",
     "unitSystem": "Unit System"


### PR DESCRIPTION
## Summary

Adds a 12-hour / 24-hour time format setting to Settings > General, stored in localStorage.
The preference is applied to all time displays across the web app: history table, session detail sheet, plays chart, concurrent streams chart, hour-of-day chart, hourly distribution chart, library overview (last updated + peak hour), and watch page (peak hour).
Defaults to 12-hour. Web only - no mobile changes.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

Closes #329

## Screenshots

<img width="490" height="138" alt="image" src="https://github.com/user-attachments/assets/fa22fe14-6ab9-4302-b434-2fc912bb9d7e" />

## Testing

- [ ] Added/updated unit tests
- [X] Ran test suite locally (`pnpm test:unit`)
- [X] Tested manually

<!-- If manual testing, describe what you did: -->

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [X] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [X] Self-reviewed
- [X] No new warnings from `pnpm typecheck`
- [X] Tests pass locally
