### PR TITLE
fix: favicon not displaying on safari

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9,7 +9,9 @@
     <meta name="description" content="Streaming access manager for Plex and Jellyfin. Detect account sharing with impossible travel, simultaneous locations, and device velocity rules." />
 
     <!-- Favicon & Icons -->
+    <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 
     <!-- PWA -->


### PR DESCRIPTION
## Summary

- Safari's SVG favicon support is inconsistent, particularly with multiple tabs. By declaring the .ico first, Safari picks that up instead of failing and falling back to the "P" letter icon.
- Kept the SVG icon for browsers that do support it (Chrome, Firefox).
- The icons were already in the repo, so I didn't need to add them

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

Closes #399 

## Testing

- [ ] Added/updated unit tests
- [X] Ran test suite locally (`pnpm test:unit`)
- [ ] Tested manually

Don't have Safari so couldn't actually test, but should be fine.

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [X] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [X] Self-reviewed
- [X] No new warnings from `pnpm typecheck`
- [X] Tests pass locally
