### PR TITLE
fix: NaN label on negative growth rate

### DIFF
--- a/apps/web/src/pages/library/Storage.tsx
+++ b/apps/web/src/pages/library/Storage.tsx
@@ -86,6 +86,20 @@ export function LibraryStorage() {
     (staleSummary.data?.summary.neverWatched.sizeBytes ?? 0) +
     (staleSummary.data?.summary.stale.sizeBytes ?? 0);
 
+  // Growth rate display - show "0 GB/mo" for zero/negative/NaN growth
+  const insufficientData =
+    storage.data?.predictions.currentDataDays &&
+    storage.data.predictions.currentDataDays < (storage.data.predictions.minDataDays ?? 7);
+  const growthBytes = Number(storage.data?.growthRate?.bytesPerMonth ?? 0);
+  const growthRateDisplay = insufficientData
+    ? 'Insufficient data'
+    : growthBytes > 0
+      ? `+${formatBytes(storage.data?.growthRate.bytesPerMonth)}/mo`
+      : '0 GB/mo';
+  const growthRateSubValue = insufficientData
+    ? `${storage.data?.predictions.currentDataDays} of ${storage.data?.predictions.minDataDays} days`
+    : undefined;
+
   // Header component (used in all states)
   const header = (
     <div>
@@ -136,18 +150,8 @@ export function LibraryStorage() {
         <StatCard
           icon={TrendingUp}
           label="Growth Rate"
-          value={
-            storage.data?.predictions.currentDataDays &&
-            storage.data.predictions.currentDataDays < (storage.data.predictions.minDataDays ?? 7)
-              ? 'Insufficient data'
-              : `+${formatBytes(storage.data?.growthRate.bytesPerMonth)}/mo`
-          }
-          subValue={
-            storage.data?.predictions.currentDataDays &&
-            storage.data.predictions.currentDataDays < (storage.data.predictions.minDataDays ?? 7)
-              ? `${storage.data.predictions.currentDataDays} of ${storage.data.predictions.minDataDays} days`
-              : undefined
-          }
+          value={growthRateDisplay}
+          subValue={growthRateSubValue}
           isLoading={storage.isLoading}
         />
         <StatCard


### PR DESCRIPTION
## Summary

Extracted the growth rate display logic into computed variables that check growthBytes > 0 before formatting.
When the growth rate is zero, negative, or NaN, it shows "0 GB/mo" instead.
No new language strings added.

The three cases:
- Insufficient data (< minDataDays of history) → "Insufficient data" (unchanged)
- Positive growth → "+X.XX GB/mo" (unchanged)
- Zero, negative, or NaN growth → "0 GB/mo" (was "+NaN undefined/mo")

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

<!-- Link to issue if applicable. Features should have been discussed first in Discussions or Discord. -->

Closes #401 

<!-- For UI changes. Delete this section otherwise. -->

## Testing

- [ ] Added/updated unit tests
- [X] Ran test suite locally (`pnpm test:unit`)
- [ ] Tested manually

<!-- If manual testing, describe what you did: -->

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [X] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [X] Self-reviewed
- [X] No new warnings from `pnpm typecheck`
- [X] Tests pass locally
