### PR TITLE
fix: stream map background color

### DIFF
--- a/apps/web/src/components/map/StreamMap.tsx
+++ b/apps/web/src/components/map/StreamMap.tsx
@@ -50,6 +50,7 @@ const mapStyles = `
   /* Ensure map container doesn't overlap sidebars/modals */
   .leaflet-container {
     z-index: 0 !important;
+    background: hsl(var(--background)) !important;
   }
   .leaflet-pane {
     z-index: 1 !important;


### PR DESCRIPTION
## Summary

stops hedsick complaining about whitespace on the map page when the toolbar is closed

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

<!-- Link to issue if applicable. Features should have been discussed first in Discussions or Discord. -->

Closes #462

## Changes

css

## Screenshots

<!-- For UI changes. Delete this section otherwise. -->

## Testing

- [ ] Added/updated unit tests
- [X] Ran test suite locally (`pnpm test:unit`)
- [X] Tested manually

<!-- If manual testing, describe what you did: -->

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [X] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [X] Self-reviewed
- [X] No new warnings from `pnpm typecheck`
- [X] Tests pass locally
