### PR TITLE
health gate redis fix

### DIFF
--- a/apps/server/src/serverState.ts
+++ b/apps/server/src/serverState.ts
@@ -13,6 +13,7 @@ let _mode: ServerMode = 'starting';
 let _wasReady = false;
 let _servicesInitialized = false;
 let _dbHealthy = false;
+let _redisHealthy = false;
 const _listeners: ModeChangeListener[] = [];
 
 export function getServerMode(): ServerMode {
@@ -59,4 +60,13 @@ export function isDbHealthy(): boolean {
 
 export function setDbHealthy(v: boolean): void {
   _dbHealthy = v;
+}
+
+/** Cached Redis health — updated by startup probe, recovery loop, and ioredis events. */
+export function isRedisHealthy(): boolean {
+  return _redisHealthy;
+}
+
+export function setRedisHealthy(v: boolean): void {
+  _redisHealthy = v;
 }


### PR DESCRIPTION
## Summary

Fix `/health` endpoint reporting stale `redis: false` during maintenance mode, even after Redis becomes available.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Changes

- Added `isRedisHealthy()` / `setRedisHealthy()` to `serverState.ts`, matching the existing `isDbHealthy` pattern
- Replaced `app.redis.status === 'ready'` checks in `/health` endpoint and DB health interval with `isRedisHealthy()`
- Wired `setRedisHealthy()` into the startup probe, recovery loop, and ioredis `close`/`ready` event handlers

## Testing

- [ ] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

Diagnosed root cause and implemented fix.

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
