### PR TITLE
Add support for custom number of days in stale content and align dropdown to be buttons like other views

### DIFF
--- a/apps/web/src/components/library/StaleContentTabs.tsx
+++ b/apps/web/src/components/library/StaleContentTabs.tsx
@@ -117,6 +117,10 @@ type DaysPreset = 30 | 90 | 180 | 365 | 730;
 
 const PRESETS: DaysPreset[] = [30, 90, 180, 365, 730];
 
+/**
+ * Format the custom days button label. Returns 'Custom' when no custom value is set,
+ * otherwise returns an abbreviated human-readable string (e.g. '45 days', '3mo', '2y').
+ */
 function formatCustomLabel(isCustomDays: boolean, staleDays: number): string {
   if (!isCustomDays) return 'Custom';
   if (staleDays < 30) return staleDays === 1 ? '1 day' : `${staleDays} days`;
@@ -438,7 +442,7 @@ export function StaleContentTabs({ serverId, libraryId }: StaleContentTabsProps)
                     )}
                   >
                     <CalendarIcon className="h-3.5 w-3.5" />
-                    <span>{formatCustomLabel(isCustomDays, staleDays)}</span>
+                    {formatCustomLabel(isCustomDays, staleDays)}
                   </button>
                 </PopoverTrigger>
                 <PopoverContent className="w-80" align="end">


### PR DESCRIPTION
## Summary
Aligns the the stale content date ranges to be similar to other components and adds a custom days field 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Breaking change

## Related Issue

https://github.com/connorgallopo/Tracearr/discussions/411

## Changes
- Replaced the select drop down with default buttons 
- added a custom button that lets you specify any amount of days
- Changed `staleDays` to be a number instead of casting to a string
- Added a check for isCustomDays to detect when to highlight a button
- Validate input with Number.IsFinite instead of `!isNaN`

## Screenshots

Before:
https://github.com/user-attachments/assets/1f4b7114-0624-4f85-95a6-d330e48ecd2b

After:
https://github.com/user-attachments/assets/271e3f71-fd26-4ab8-9622-1ad27758ea4e



## Testing

- [ ] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

<!-- If manual testing, describe what you did: -->

## AI Disclosure

- [x] AI tools were used significantly in writing this code

I am not a front end developer by trade so the initial implementation was done with the use of AI and i did some cleanup. 

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
