### PR TITLE
Introduce dns caching, disabled by default

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -49,6 +49,7 @@
     "@tracearr/shared": "workspace:*",
     "bcrypt": "^6.0.0",
     "bullmq": "^5.67.3",
+    "cacheable-lookup": "^7.0.0",
     "dotenv": "^17.2.4",
     "drizzle-orm": "^0.45.1",
     "eventsource": "^4.1.0",
@@ -63,6 +64,7 @@
     "sharp": "^0.34.0",
     "socket.io": "^4.8.3",
     "stream-json": "^1.9.1",
+    "undici": "^7.22.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -21,6 +21,9 @@ const PROJECT_ROOT = resolve(__dirname, '../../..');
 // Load .env from project root
 config({ path: resolve(PROJECT_ROOT, '.env'), quiet: true });
 
+// Set global DNS cache (must be after dotenv so DNS_CACHE_MAX_TTL is available)
+await import('./utils/dnsCache.js');
+
 // GeoIP database path (in project root/data)
 const GEOIP_DB_PATH = resolve(PROJECT_ROOT, 'data/GeoLite2-City.mmdb');
 const GEOASN_DB_PATH = resolve(PROJECT_ROOT, 'data/GeoLite2-ASN.mmdb');

--- a/apps/server/src/utils/dnsCache.ts
+++ b/apps/server/src/utils/dnsCache.ts
@@ -1,0 +1,34 @@
+/**
+ * DNS Cache Utility
+ *
+ * When DNS_CACHE_MAX_TTL is set, configures a global undici dispatcher with
+ * DNS caching via cacheable-lookup. All fetch() calls then use cached resolution.
+ *
+ * Each record's TTL from the authoritative DNS server is respected — records
+ * expire when the zone's TTL says they should. DNS_CACHE_MAX_TTL only caps
+ * the upper bound (e.g., if a zone returns a 1-hour TTL, we still expire
+ * after maxTtl seconds). It does not override shorter TTLs.
+ *
+ * Errors (NXDOMAIN, SERVFAIL) are cached for only 0.15s by default,
+ * so transient DNS failures do not persist across poll cycles.
+ *
+ * Import this module early in server startup (side-effect import).
+ */
+
+import type dns from 'node:dns';
+
+if (process.env.DNS_CACHE_MAX_TTL) {
+  const maxTtl = parseInt(process.env.DNS_CACHE_MAX_TTL, 10);
+  const { default: CacheableLookup } = await import('cacheable-lookup');
+  const { Agent, setGlobalDispatcher } = await import('undici');
+
+  const cacheable = new CacheableLookup({ maxTtl });
+
+  setGlobalDispatcher(
+    new Agent({
+      connect: { lookup: cacheable.lookup.bind(cacheable) as typeof dns.lookup },
+    })
+  );
+
+  console.info(`[DNS] Cache enabled (max TTL: ${maxTtl}s)`);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       bullmq:
         specifier: ^5.67.3
         version: 5.67.3
+      cacheable-lookup:
+        specifier: ^7.0.0
+        version: 7.0.0
       dotenv:
         specifier: ^17.2.4
         version: 17.2.4
@@ -354,6 +357,9 @@ importers:
       stream-json:
         specifier: ^1.9.1
         version: 1.9.1
+      undici:
+        specifier: ^7.22.0
+        version: 7.22.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -4145,6 +4151,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cacheable-lookup@7.0.0:
+    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
+    engines: {node: '>=14.16'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -8522,8 +8532,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.21.0:
-    resolution: {integrity: sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==}
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -13466,6 +13476,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cacheable-lookup@7.0.0: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -14657,7 +14669,7 @@ snapshots:
     dependencies:
       promise-limit: 2.7.0
       promise-retry: 2.0.1
-      undici: 7.21.0
+      undici: 7.22.0
 
   expo-server@55.0.4: {}
 
@@ -18361,7 +18373,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.21.0: {}
+  undici@7.22.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Add opt-in DNS caching for all outbound `fetch()` calls via `cacheable-lookup` and a global undici dispatcher.

Disabled by default, use `DNS_CACHE_MAX_TTL` to enable (value is in seconds).

When enabled, repeated requests to the same hostname (e.g., media server polling every 30s) reuse cached DNS results instead of performing a fresh lookup each time.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

## Changes

- New `dnsCache.ts` utility that conditionally sets a global undici dispatcher with DNS caching
- Loaded as a side-effect import in `index.ts` after dotenv, so `DNS_CACHE_MAX_TTL` is available from `.env`
- Respects each DNS record's authoritative TTL; `DNS_CACHE_MAX_TTL` only caps the upper bound
- Errors (NXDOMAIN, SERVFAIL) are cached for only 0.15s — transient failures don't persist across poll cycles
- Disabled by default — set `DNS_CACHE_MAX_TTL=120` (seconds) to enable

## Testing

- [ ] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Verified DNS caching activates when `DNS_CACHE_MAX_TTL` is set and logs `[DNS] Cache enabled (max TTL: Xs)` on startup. Confirmed no regressions with `pnpm typecheck` and `pnpm test`.

I configured docker compose to use an external DNS server, and used `tcpdump` to verify lookup traffic ceased from the SSE poller

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
