### PR TITLE
Add user filter to v1/public/history endpoint, api-docs formatting updates

### DIFF
--- a/apps/server/src/routes/public.openapi.ts
+++ b/apps/server/src/routes/public.openapi.ts
@@ -46,6 +46,11 @@ const ServerIdParam = z.uuid().openapi({
   example: '550e8400-e29b-41d4-a716-446655440000',
 });
 
+const UserIdParam = z.uuid().openapi({
+  description: 'User UUID',
+  example: 'b9c41fea-44ca-45cd-b725-945c635a94bd',
+});
+
 const PaginationQuery = z.object({
   page: z.coerce.number().int().positive().default(1).openapi({ example: 1 }),
   pageSize: z.coerce.number().int().positive().max(100).default(25).openapi({ example: 25 }),
@@ -490,6 +495,7 @@ registry.registerPath({
 
 const HistoryQuery = PaginationQuery.extend({
   serverId: ServerIdParam.optional().openapi({ description: 'Filter by server' }),
+  user: UserIdParam.optional().openapi({ description: 'Filter by user' }),
   state: PlaybackStateEnum.optional(),
   mediaType: MediaTypeEnum.optional(),
   startDate: z.coerce.date().optional().openapi({

--- a/apps/server/src/routes/public.ts
+++ b/apps/server/src/routes/public.ts
@@ -169,8 +169,8 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
     if (allServers.length > 0) {
       const serverIds = allServers.map((s) => s.id);
       const serverListDescription =
-        'Filter to specific server. Available servers:\n' +
-        allServers.map((s) => `• **${s.name}**: \`${s.id}\``).join('\n');
+        'Filter to specific server. Available servers:\n\n' +
+        allServers.map((s) => `• **${s.name}**: \`${s.id}\``).join('\n\n');
 
       const paths = spec.paths as Record<string, Record<string, unknown>> | undefined;
       if (paths) {
@@ -186,6 +186,42 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
                   }
                   // Update description to list available servers
                   param.description = serverListDescription;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Fetch users to populate user dropdown
+    const allUsers = await db
+      .select({ id: users.id, username: users.username, name: users.name })
+      .from(users)
+      .innerJoin(serverUsers, eq(users.id, serverUsers.userId))
+      .groupBy(users.id, users.username, users.name)
+      .orderBy(users.username);
+
+    if (allUsers.length > 0) {
+      const userIds = allUsers.map((u) => u.id);
+      const userListDescription =
+        'Filter by user. Available users:\n\n' +
+        allUsers.map((u) => `• **${u.name ?? u.username}**: \`${u.id}\``).join('\n\n');
+
+      const paths = spec.paths as Record<string, Record<string, unknown>> | undefined;
+      if (paths) {
+        for (const pathObj of Object.values(paths)) {
+          for (const methodObj of Object.values(pathObj)) {
+            const method = methodObj as { parameters?: Array<Record<string, unknown>> };
+            if (method.parameters) {
+              for (const param of method.parameters) {
+                if (param.name === 'user' && param.in === 'query') {
+                  const schema = param.schema as Record<string, unknown> | undefined;
+                  if (schema) {
+                    schema.enum = userIds;
+                  }
+                  // Update description to list available users
+                  param.description = userListDescription;
                 }
               }
             }
@@ -614,6 +650,7 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
   app.get('/history', { preHandler: [app.authenticatePublicApi] }, async (request, reply) => {
     const querySchema = paginationSchema.extend({
       serverId: z.uuid().optional(),
+      user: z.uuid().optional(),
       state: z.enum(['playing', 'paused', 'stopped']).optional(),
       mediaType: z.enum(['movie', 'episode', 'track', 'live', 'photo', 'unknown']).optional(),
       startDate: z.coerce.date().optional(),
@@ -626,7 +663,8 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
       return reply.badRequest('Invalid query parameters');
     }
 
-    const { page, pageSize, serverId, state, mediaType, startDate, endDate, timezone } = query.data;
+    const { page, pageSize, serverId, user, state, mediaType, startDate, endDate, timezone } =
+      query.data;
     const offset = (page - 1) * pageSize;
 
     // Validate date range
@@ -638,6 +676,10 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
     // Dates are converted to UTC based on the provided timezone
     const conditions: ReturnType<typeof sql>[] = [];
     if (serverId) conditions.push(sql`s.server_id = ${serverId}`);
+    if (user)
+      conditions.push(
+        sql`s.server_user_id IN (SELECT su_f.id FROM server_users su_f WHERE su_f.user_id = ${user})`
+      );
     if (state) conditions.push(sql`s.state = ${state}`);
     if (mediaType) conditions.push(sql`s.media_type = ${mediaType}`);
     if (startDate) {


### PR DESCRIPTION

## Summary

Added a `user` option to history service call to allow for more finely-grained filtering. Currently only supports filtering for a single user.

Also made some api docs formatting updates for `user` as well as `serverId` to improve readability. I am happy to revert these changes if they are counter to the project's design philosophy, or if they are simply disliked.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

N/A

## Changes

<!-- What specifically changed? -->

- Added new `UserIdParam` shared variable and passed to history svc request
- Grabbed user id from db during history req
- Added new user option to api-docs, including "get all users" dropdown (copying "get all servers" logic)
- Added an extra line breaks to some run-on lines in the api-docs (`serverId` and `user` only, see screenshots)

## Screenshots

<!-- For UI changes. Delete this section otherwise. -->

post-code change
<img width="1311" height="585" alt="Screenshot 2026-02-21 at 2 59 36 PM" src="https://github.com/user-attachments/assets/6e2d30ad-cdf7-4bd3-81b8-bf64e9166831" />

**pre-formatting-change** example of how user section (and server section, if you have many servers) looks 
<img width="1296" height="213" alt="Screenshot 2026-02-21 at 3 00 06 PM" src="https://github.com/user-attachments/assets/bf551fae-ba0e-406e-bc24-275d94b581f7" />
again, happy to revert if desired.

## Testing

- [ ] Added/updated unit tests
- [X] Ran test suite locally (`pnpm test:unit`)
- [X] Tested manually

<!-- If manual testing, describe what you did: -->

For manual testing, I spun up test container connected to my personal media server, watched an show, and tried filtering. Was able to successfully see history item when user was selected, whereas response was empty when other users were selected.

## AI Disclosure

- [X] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->
Used Claude CLI to generate initial implementation.

## Checklist

- [X] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [X] Self-reviewed
- [X] No new warnings from `pnpm typecheck`
- [X] Tests pass locally
