### PR TITLE
Add local-ci script and pre-push tip for running full CI locally

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,3 +2,7 @@ pnpm typecheck
 pnpm test:unit
 pnpm lint
 pnpm translations:check
+
+echo ""
+echo "Tip: Run 'pnpm local-ci' to mimic the full PR CI pipeline."
+echo ""

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:e2e": "turbo test:e2e",
     "test:watch": "turbo test:watch",
     "test:coverage": "turbo test:coverage",
+    "local-ci": "docker compose -f docker/docker-compose.test.yml up -d --wait && pnpm lint && pnpm typecheck && pnpm test:unit && pnpm test:services && pnpm test:routes && pnpm test:security && pnpm test:integration && CI=true pnpm test:e2e && pnpm test:coverage && pnpm translations:check; docker compose -f docker/docker-compose.test.yml down --volumes",
     "test:unit:coverage": "turbo test:unit:coverage",
     "test:services:coverage": "turbo test:services:coverage",
     "test:routes:coverage": "turbo test:routes:coverage",


### PR DESCRIPTION
## Summary

Adds a `pnpm local-ci` script that runs the full PR CI pipeline locally in one command, and a tip in the pre-push hook to remind contributors it exists.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Breaking change

## Related Issue

N/A

## Changes

- Added `local-ci` script to root `package.json` that spins up test Docker containers, runs lint, typecheck, all test suites (unit, services, routes, security, integration, e2e, coverage), and translations check, then tears down containers afterward
- Uses `CI=true` for e2e tests to prevent Playwright from blocking on the HTML report server on failure
- Uses `;` before `docker compose down` to ensure containers are always cleaned up, even on failure
- Added a tip message at the end of the `.husky/pre-push` hook pointing users to `pnpm local-ci`

## Testing

- [ ] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Ran `pnpm local-ci` end-to-end to verify the script starts containers, runs all checks, and tears down containers on both success and failure.

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
