### PR TITLE
reworked plex resource cards. made draggable, responsive, and more.

### DIFF
--- a/apps/web/src/components/charts/BandwidthChart.tsx
+++ b/apps/web/src/components/charts/BandwidthChart.tsx
@@ -115,12 +115,6 @@ export function ServerBandwidthChart({
       remoteData.push([x, (point.wanBytes * 8) / point.timespan]);
     }
 
-    // Dynamic y-axis max: 20% above peak value so the chart fills the space
-    // Minimum of 1000 bps (1 Kbps) so the y-axis always has labels, even with zero traffic
-    const allValues = [...localData, ...remoteData].map(([, y]) => y);
-    const peakValue = Math.max(...allValues, 0);
-    const yMax = Math.max(1000, Math.ceil(peakValue * 1.2));
-
     return {
       chart: {
         type: 'area',
@@ -168,7 +162,7 @@ export function ServerBandwidthChart({
         },
         gridLineColor: 'hsl(var(--border) / 0.5)',
         min: 0,
-        max: yMax,
+        softMax: 1000, // 1 Kbps floor so the axis has labels when traffic is zero
       },
       plotOptions: {
         area: {

--- a/apps/web/src/components/charts/DraggableResourceCards.tsx
+++ b/apps/web/src/components/charts/DraggableResourceCards.tsx
@@ -1,0 +1,393 @@
+import { useState, useMemo, useCallback } from 'react';
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  pointerWithin,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDraggable,
+  useDroppable,
+  type DragStartEvent,
+  type DragEndEvent,
+  type CollisionDetection,
+} from '@dnd-kit/core';
+import { arrayMove } from '@dnd-kit/sortable';
+import { GripVertical, Cpu, MemoryStick, ArrowUpDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { ServerResourceDataPoint, ServerBandwidthDataPoint } from '@tracearr/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ResourceChart } from '@/components/charts/ServerResourceCharts';
+import { ServerBandwidthChart } from '@/components/charts/BandwidthChart';
+import { useResourceCardLayout, type CardId } from '@/hooks/useResourceCardLayout';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+export const ROW_GAP_PREFIX = 'row-gap:';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface DraggableResourceCardsProps {
+  resourceData: ServerResourceDataPoint[] | undefined;
+  resourceLoading?: boolean;
+  resourceAverages?: {
+    hostCpu: number;
+    processCpu: number;
+    hostMemory: number;
+    processMemory: number;
+  } | null;
+  bandwidthData: ServerBandwidthDataPoint[] | undefined;
+  bandwidthLoading?: boolean;
+  bandwidthAverages?: {
+    local: number;
+    remote: number;
+  } | null;
+  bandwidthPollInterval: number;
+  onBandwidthPollIntervalChange: (interval: number) => void;
+}
+
+// ─── Collision detection ─────────────────────────────────────────────────────
+
+// Cards take priority when the pointer is directly over one (enables cross-row
+// joining). Gap zones only win when the pointer is in the strip between rows.
+const customCollisionDetection: CollisionDetection = (args) => {
+  const allHits = pointerWithin(args);
+
+  const cardHits = allHits.filter((c) => !String(c.id).startsWith(ROW_GAP_PREFIX));
+  if (cardHits.length > 0) return cardHits;
+
+  const gapHits = allHits.filter((c) => String(c.id).startsWith(ROW_GAP_PREFIX));
+  if (gapHits.length > 0) return gapHits;
+
+  return closestCenter(args);
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const CARD_CONFIG: Record<CardId, { titleKey: string; icon: React.ReactNode }> = {
+  cpu: { titleKey: 'CPU', icon: <Cpu className="h-4 w-4" /> },
+  ram: { titleKey: 'RAM', icon: <MemoryStick className="h-4 w-4" /> },
+  bandwidth: { titleKey: 'dashboard.bandwidth', icon: <ArrowUpDown className="h-4 w-4" /> },
+};
+
+export function getFlexBasis(cardsInRow: number): string {
+  if (cardsInRow === 3) return 'calc(33.333% - 0.667rem)';
+  if (cardsInRow === 2) return 'calc(50% - 0.5rem)';
+  return '100%';
+}
+
+export function findCardRowInLayout(layout: CardId[][], cardId: string): number {
+  return layout.findIndex((row) => row.includes(cardId as CardId));
+}
+
+/** Compute a new layout by moving `activeId` next to `overId` (joining its row),
+ *  or into a new row at `gapPosition` if dropping on a gap zone. */
+export function computeNewLayout(
+  rows: CardId[][],
+  activeId: CardId,
+  overId: string
+): CardId[][] | null {
+  const isGap = overId.startsWith(ROW_GAP_PREFIX);
+
+  if (isGap) {
+    const gapPosition = parseInt(overId.slice(ROW_GAP_PREFIX.length), 10);
+    const srcRow = findCardRowInLayout(rows, activeId);
+    if (srcRow === -1) return null;
+
+    const newRows = rows.map((r) => [...r]);
+    newRows[srcRow] = newRows[srcRow]!.filter((id) => id !== activeId);
+    const insertAt = Math.min(gapPosition, newRows.length);
+    newRows.splice(insertAt, 0, [activeId]);
+    return newRows.filter((r) => r.length > 0);
+  }
+
+  // Card-to-card
+  const srcRowIdx = findCardRowInLayout(rows, activeId);
+  const tgtRowIdx = findCardRowInLayout(rows, overId);
+  if (srcRowIdx === -1 || tgtRowIdx === -1) return null;
+
+  if (srcRowIdx === tgtRowIdx) {
+    const newRows = rows.map((r) => [...r]);
+    const row = newRows[srcRowIdx]!;
+    const oldIdx = row.indexOf(activeId);
+    const newIdx = row.indexOf(overId as CardId);
+    if (oldIdx === -1 || newIdx === -1) return null;
+    newRows[srcRowIdx] = arrayMove(row, oldIdx, newIdx);
+    return newRows;
+  }
+
+  // Cross-row — join target row
+  const newRows = rows.map((r) => [...r]);
+  newRows[srcRowIdx] = newRows[srcRowIdx]!.filter((id) => id !== activeId);
+  const tgtRow = newRows[tgtRowIdx]!;
+  const overIdx = tgtRow.indexOf(overId as CardId);
+  if (overIdx === -1) return null;
+  tgtRow.splice(overIdx + 1, 0, activeId);
+  return newRows.filter((r) => r.length > 0);
+}
+
+// ─── Draggable + Droppable card wrapper ──────────────────────────────────────
+
+// No state updates during drag. `isOver` comes from dnd-kit's internal store
+// and renders a highlight ring — zero custom state, zero feedback loops.
+function DraggableCardSlot({
+  id,
+  flexBasis,
+  isDragActive,
+  children,
+}: {
+  id: string;
+  flexBasis: string;
+  isDragActive: boolean;
+  children: React.ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef: setDraggableRef, isDragging } = useDraggable({ id });
+
+  const { setNodeRef: setDroppableRef, isOver } = useDroppable({ id });
+
+  const combinedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      setDraggableRef(node);
+      setDroppableRef(node);
+    },
+    [setDraggableRef, setDroppableRef]
+  );
+
+  const showDropHighlight = isOver && isDragActive && !isDragging;
+
+  return (
+    <div
+      ref={combinedRef}
+      style={{ flexBasis, minWidth: 280, flexShrink: 1, flexGrow: 1 }}
+      className={`group relative transition-opacity duration-150 ${
+        isDragging ? 'opacity-40' : ''
+      } ${showDropHighlight ? 'ring-primary ring-offset-background rounded-xl ring-2 ring-offset-2' : ''}`}
+    >
+      <button
+        className="text-muted-foreground hover:text-foreground absolute top-3.5 left-1.5 z-10 cursor-grab rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100 active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      {children}
+    </div>
+  );
+}
+
+// ─── Row gap drop zone ───────────────────────────────────────────────────────
+
+function RowGapDropZone({ position, isDragActive }: { position: number; isDragActive: boolean }) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `${ROW_GAP_PREFIX}${position}`,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ flexBasis: '100%', height: !isDragActive ? 0 : isOver ? 48 : 32 }}
+      className={`w-full overflow-hidden ${
+        !isDragActive
+          ? ''
+          : isOver
+            ? 'border-primary bg-primary/5 rounded-md border-2 border-dashed'
+            : 'border-muted-foreground/30 rounded-md border border-dashed'
+      }`}
+    />
+  );
+}
+
+// ─── Drag overlay ────────────────────────────────────────────────────────────
+
+function CardDragOverlay({ cardId }: { cardId: CardId }) {
+  const { t } = useTranslation(['pages']);
+  const config = CARD_CONFIG[cardId];
+  const title = cardId === 'bandwidth' ? t('dashboard.bandwidth') : config.titleKey;
+
+  return (
+    <Card className="ring-primary/20 w-[300px] shadow-lg ring-2">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          {config.icon}
+          {String(title)}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="bg-muted/50 text-muted-foreground flex h-[180px] items-center justify-center rounded-lg text-sm">
+          Chart
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Main component ──────────────────────────────────────────────────────────
+
+export function DraggableResourceCards({
+  resourceData,
+  resourceLoading,
+  resourceAverages,
+  bandwidthData,
+  bandwidthLoading,
+  bandwidthAverages,
+  bandwidthPollInterval,
+  onBandwidthPollIntervalChange,
+}: DraggableResourceCardsProps) {
+  const { layout, setLayout } = useResourceCardLayout();
+  const [activeId, setActiveId] = useState<CardId | null>(null);
+
+  // No preview state. Cards stay at their committed sizes during drag.
+  // Visual feedback is handled by dnd-kit's `isOver` (ring highlight on
+  // drop targets). Layout only changes on drop — zero state updates during
+  // drag, zero re-renders, zero feedback loops.
+  const activeRows = layout.rows;
+
+  const cardFlexMap = useMemo(() => {
+    const map = new Map<CardId, string>();
+    for (const row of activeRows) {
+      const basis = getFlexBasis(row.length);
+      for (const id of row) map.set(id, basis);
+    }
+    return map;
+  }, [activeRows]);
+
+  const flatOrder = useMemo(() => activeRows.flat(), [activeRows]);
+  const rowStartIndices = useMemo(() => {
+    const starts = new Set<number>();
+    let offset = 0;
+    for (const row of activeRows) {
+      starts.add(offset);
+      offset += row.length;
+    }
+    return starts;
+  }, [activeRows]);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(event.active.id as CardId);
+  }, []);
+
+  // No onDragOver handler. Zero state updates during drag.
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      setActiveId(null);
+
+      if (!over || active.id === over.id) return;
+
+      const newLayout = computeNewLayout(layout.rows, active.id as CardId, String(over.id));
+      if (newLayout) {
+        setLayout({ rows: newLayout });
+        // Highcharts reflow after layout change
+        setTimeout(() => {
+          window.dispatchEvent(new Event('resize'));
+        }, 250);
+      }
+    },
+    [layout.rows, setLayout]
+  );
+
+  const handleDragCancel = useCallback(() => {
+    setActiveId(null);
+  }, []);
+
+  function renderCard(cardId: CardId) {
+    switch (cardId) {
+      case 'cpu':
+        return (
+          <ResourceChart
+            title="CPU"
+            icon={<Cpu className="h-4 w-4" />}
+            data={resourceData}
+            processKey="processCpuUtilization"
+            hostKey="hostCpuUtilization"
+            processAvg={resourceAverages?.processCpu}
+            hostAvg={resourceAverages?.hostCpu}
+            isLoading={resourceLoading}
+          />
+        );
+      case 'ram':
+        return (
+          <ResourceChart
+            title="RAM"
+            icon={<MemoryStick className="h-4 w-4" />}
+            data={resourceData}
+            processKey="processMemoryUtilization"
+            hostKey="hostMemoryUtilization"
+            processAvg={resourceAverages?.processMemory}
+            hostAvg={resourceAverages?.hostMemory}
+            isLoading={resourceLoading}
+          />
+        );
+      case 'bandwidth':
+        return (
+          <ServerBandwidthChart
+            data={bandwidthData}
+            isLoading={bandwidthLoading}
+            averages={bandwidthAverages}
+            pollInterval={bandwidthPollInterval}
+            onPollIntervalChange={onBandwidthPollIntervalChange}
+          />
+        );
+    }
+  }
+
+  const isDragActive = activeId !== null;
+  const renderItems: React.ReactNode[] = [];
+  let rowCounter = 0;
+
+  renderItems.push(<RowGapDropZone key="gap-0" position={0} isDragActive={isDragActive} />);
+
+  for (let i = 0; i < flatOrder.length; i++) {
+    const cardId = flatOrder[i]!;
+
+    if (i > 0 && rowStartIndices.has(i)) {
+      rowCounter++;
+      renderItems.push(
+        <RowGapDropZone
+          key={`gap-${rowCounter}`}
+          position={rowCounter}
+          isDragActive={isDragActive}
+        />
+      );
+    }
+
+    renderItems.push(
+      <DraggableCardSlot
+        key={cardId}
+        id={cardId}
+        flexBasis={cardFlexMap.get(cardId) ?? '100%'}
+        isDragActive={isDragActive}
+      >
+        {renderCard(cardId)}
+      </DraggableCardSlot>
+    );
+  }
+
+  renderItems.push(
+    <RowGapDropZone
+      key={`gap-${rowCounter + 1}`}
+      position={rowCounter + 1}
+      isDragActive={isDragActive}
+    />
+  );
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={customCollisionDetection}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <div className="flex flex-wrap gap-x-4 gap-y-4">{renderItems}</div>
+
+      <DragOverlay dropAnimation={null}>
+        {activeId ? <CardDragOverlay cardId={activeId} /> : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/apps/web/src/components/charts/ServerResourceCharts.tsx
+++ b/apps/web/src/components/charts/ServerResourceCharts.tsx
@@ -4,8 +4,6 @@ import HighchartsReact from 'highcharts-react-official';
 import type { ServerResourceDataPoint } from '@tracearr/shared';
 import { ChartSkeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Cpu, MemoryStick } from 'lucide-react';
-
 // Colors matching Plex's style
 const COLORS = {
   process: '#00b4e4', // Plex-style cyan for "Plex Media Server"
@@ -16,18 +14,7 @@ const COLORS = {
   systemGradientEnd: 'rgba(204, 123, 159, 0.05)',
 };
 
-interface ServerResourceChartsProps {
-  data: ServerResourceDataPoint[] | undefined;
-  isLoading?: boolean;
-  averages?: {
-    hostCpu: number;
-    processCpu: number;
-    hostMemory: number;
-    processMemory: number;
-  } | null;
-}
-
-interface ResourceChartProps {
+export interface ResourceChartProps {
   title: string;
   icon: React.ReactNode;
   data: ServerResourceDataPoint[] | undefined;
@@ -52,7 +39,7 @@ const X_LABELS: Record<number, string> = {
 /**
  * Single resource chart (CPU or RAM)
  */
-function ResourceChart({
+export function ResourceChart({
   title,
   icon,
   data,
@@ -315,36 +302,5 @@ function ResourceChart({
         </div>
       </CardContent>
     </Card>
-  );
-}
-
-/**
- * Server resource monitoring charts (CPU + RAM)
- * Displays real-time server resource utilization matching Plex's dashboard style
- */
-export function ServerResourceCharts({ data, isLoading, averages }: ServerResourceChartsProps) {
-  return (
-    <div className="grid gap-4 md:grid-cols-2">
-      <ResourceChart
-        title="CPU"
-        icon={<Cpu className="h-4 w-4" />}
-        data={data}
-        processKey="processCpuUtilization"
-        hostKey="hostCpuUtilization"
-        processAvg={averages?.processCpu}
-        hostAvg={averages?.hostCpu}
-        isLoading={isLoading}
-      />
-      <ResourceChart
-        title="RAM"
-        icon={<MemoryStick className="h-4 w-4" />}
-        data={data}
-        processKey="processMemoryUtilization"
-        hostKey="hostMemoryUtilization"
-        processAvg={averages?.processMemory}
-        hostAvg={averages?.hostMemory}
-        isLoading={isLoading}
-      />
-    </div>
   );
 }

--- a/apps/web/src/components/charts/__tests__/DraggableResourceCards.test.ts
+++ b/apps/web/src/components/charts/__tests__/DraggableResourceCards.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getFlexBasis,
+  findCardRowInLayout,
+  computeNewLayout,
+  ROW_GAP_PREFIX,
+} from '../DraggableResourceCards';
+import type { CardId } from '@/hooks/useResourceCardLayout';
+
+describe('getFlexBasis', () => {
+  it('returns 33% calc for 3 cards', () => {
+    expect(getFlexBasis(3)).toBe('calc(33.333% - 0.667rem)');
+  });
+
+  it('returns 50% calc for 2 cards', () => {
+    expect(getFlexBasis(2)).toBe('calc(50% - 0.5rem)');
+  });
+
+  it('returns 100% for 1 card', () => {
+    expect(getFlexBasis(1)).toBe('100%');
+  });
+
+  it('returns 100% for unexpected values', () => {
+    expect(getFlexBasis(0)).toBe('100%');
+    expect(getFlexBasis(4)).toBe('100%');
+  });
+});
+
+describe('findCardRowInLayout', () => {
+  it('finds card in single-row layout', () => {
+    expect(findCardRowInLayout([['cpu', 'ram', 'bandwidth']], 'ram')).toBe(0);
+  });
+
+  it('finds card in correct row of multi-row layout', () => {
+    const layout: CardId[][] = [['cpu'], ['ram', 'bandwidth']];
+    expect(findCardRowInLayout(layout, 'cpu')).toBe(0);
+    expect(findCardRowInLayout(layout, 'bandwidth')).toBe(1);
+  });
+
+  it('returns -1 for missing card', () => {
+    expect(findCardRowInLayout([['cpu', 'ram']], 'bandwidth')).toBe(-1);
+  });
+
+  it('returns -1 for empty layout', () => {
+    expect(findCardRowInLayout([], 'cpu')).toBe(-1);
+  });
+});
+
+describe('computeNewLayout', () => {
+  describe('gap drops', () => {
+    it('creates new row at gap position 0', () => {
+      const result = computeNewLayout([['cpu', 'ram', 'bandwidth']], 'cpu', `${ROW_GAP_PREFIX}0`);
+      expect(result).toEqual([['cpu'], ['ram', 'bandwidth']]);
+    });
+
+    it('creates new row at end', () => {
+      const result = computeNewLayout([['cpu', 'ram', 'bandwidth']], 'cpu', `${ROW_GAP_PREFIX}1`);
+      expect(result).toEqual([['ram', 'bandwidth'], ['cpu']]);
+    });
+
+    it('inserts between existing rows', () => {
+      const rows: CardId[][] = [['cpu'], ['ram', 'bandwidth']];
+      const result = computeNewLayout(rows, 'ram', `${ROW_GAP_PREFIX}1`);
+      expect(result).toEqual([['cpu'], ['ram'], ['bandwidth']]);
+    });
+
+    it('clamps gap position beyond layout length', () => {
+      const result = computeNewLayout([['cpu', 'ram', 'bandwidth']], 'cpu', `${ROW_GAP_PREFIX}99`);
+      expect(result).toEqual([['ram', 'bandwidth'], ['cpu']]);
+    });
+
+    it('removes empty source row after move', () => {
+      const rows: CardId[][] = [['cpu'], ['ram', 'bandwidth']];
+      const result = computeNewLayout(rows, 'cpu', `${ROW_GAP_PREFIX}2`);
+      expect(result).toEqual([['ram', 'bandwidth'], ['cpu']]);
+    });
+
+    it('returns null if active card not found', () => {
+      const result = computeNewLayout([['ram', 'bandwidth']], 'cpu', `${ROW_GAP_PREFIX}0`);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('same-row reorder', () => {
+    it('swaps adjacent cards', () => {
+      const result = computeNewLayout([['cpu', 'ram', 'bandwidth']], 'cpu', 'ram');
+      expect(result).toEqual([['ram', 'cpu', 'bandwidth']]);
+    });
+
+    it('moves card to end of row', () => {
+      const result = computeNewLayout([['cpu', 'ram', 'bandwidth']], 'cpu', 'bandwidth');
+      expect(result).toEqual([['ram', 'bandwidth', 'cpu']]);
+    });
+
+    it('reorders within a two-card row', () => {
+      const rows: CardId[][] = [['cpu', 'ram'], ['bandwidth']];
+      const result = computeNewLayout(rows, 'cpu', 'ram');
+      expect(result).toEqual([['ram', 'cpu'], ['bandwidth']]);
+    });
+  });
+
+  describe('cross-row join', () => {
+    it('joins target row after over card', () => {
+      const rows: CardId[][] = [['cpu', 'ram'], ['bandwidth']];
+      const result = computeNewLayout(rows, 'cpu', 'bandwidth');
+      expect(result).toEqual([['ram'], ['bandwidth', 'cpu']]);
+    });
+
+    it('removes empty source row', () => {
+      const rows: CardId[][] = [['cpu'], ['ram', 'bandwidth']];
+      const result = computeNewLayout(rows, 'cpu', 'ram');
+      expect(result).toEqual([['ram', 'cpu', 'bandwidth']]);
+    });
+
+    it('inserts after the specific target card', () => {
+      const rows: CardId[][] = [['cpu'], ['ram', 'bandwidth']];
+      const result = computeNewLayout(rows, 'cpu', 'bandwidth');
+      expect(result).toEqual([['ram', 'bandwidth', 'cpu']]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null if activeId not found in any row', () => {
+      expect(computeNewLayout([['ram', 'bandwidth']], 'cpu', 'ram')).toBeNull();
+    });
+
+    it('returns null if overId not found in target row', () => {
+      expect(computeNewLayout([['cpu'], ['ram']], 'cpu', 'bandwidth')).toBeNull();
+    });
+
+    it('does not mutate the input rows', () => {
+      const rows: CardId[][] = [['cpu', 'ram'], ['bandwidth']];
+      const original = JSON.stringify(rows);
+      computeNewLayout(rows, 'cpu', 'bandwidth');
+      expect(JSON.stringify(rows)).toBe(original);
+    });
+  });
+});

--- a/apps/web/src/hooks/__tests__/useResourceCardLayout.test.ts
+++ b/apps/web/src/hooks/__tests__/useResourceCardLayout.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  loadLayout,
+  persistLayout,
+  STORAGE_KEY,
+  DEFAULT_LAYOUT,
+  type ResourceCardLayout,
+} from '../useResourceCardLayout';
+
+// Stub localStorage for Node environment
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, value),
+  removeItem: (key: string) => storage.delete(key),
+  clear: () => storage.clear(),
+});
+
+beforeEach(() => {
+  storage.clear();
+});
+
+describe('loadLayout', () => {
+  it('returns default when nothing is stored', () => {
+    expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
+  });
+
+  it('returns default for invalid JSON', () => {
+    storage.set(STORAGE_KEY, 'not-json');
+    expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
+  });
+
+  it('returns default when rows is not an array', () => {
+    storage.set(STORAGE_KEY, '{"rows": "string"}');
+    expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
+  });
+
+  it('returns default when rows is null', () => {
+    storage.set(STORAGE_KEY, '{"rows": null}');
+    expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
+  });
+
+  it('returns default for wrong number of IDs', () => {
+    storage.set(STORAGE_KEY, '{"rows": [["cpu", "ram"]]}');
+    expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
+  });
+
+  it('returns default for duplicate IDs', () => {
+    storage.set(STORAGE_KEY, '{"rows": [["cpu", "cpu", "ram"]]}');
+    expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
+  });
+
+  it('returns default for invalid card ID', () => {
+    storage.set(STORAGE_KEY, '{"rows": [["cpu", "ram", "disk"]]}');
+    expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
+  });
+
+  it('returns default when a row is empty', () => {
+    storage.set(STORAGE_KEY, '{"rows": [[], ["cpu", "ram", "bandwidth"]]}');
+    expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
+  });
+
+  it('returns valid single-row layout', () => {
+    const layout = { rows: [['cpu', 'ram', 'bandwidth']] };
+    storage.set(STORAGE_KEY, JSON.stringify(layout));
+    expect(loadLayout()).toEqual(layout);
+  });
+
+  it('returns valid two-row layout', () => {
+    const layout = { rows: [['cpu'], ['ram', 'bandwidth']] };
+    storage.set(STORAGE_KEY, JSON.stringify(layout));
+    expect(loadLayout()).toEqual(layout);
+  });
+
+  it('returns valid three-row layout', () => {
+    const layout = { rows: [['cpu'], ['ram'], ['bandwidth']] };
+    storage.set(STORAGE_KEY, JSON.stringify(layout));
+    expect(loadLayout()).toEqual(layout);
+  });
+
+  it('accepts reordered card IDs', () => {
+    const layout = { rows: [['bandwidth', 'ram', 'cpu']] };
+    storage.set(STORAGE_KEY, JSON.stringify(layout));
+    expect(loadLayout()).toEqual(layout);
+  });
+});
+
+describe('persistLayout', () => {
+  it('writes layout to localStorage', () => {
+    const layout: ResourceCardLayout = { rows: [['cpu', 'ram', 'bandwidth']] };
+    persistLayout(layout);
+    expect(storage.get(STORAGE_KEY)).toBe(JSON.stringify(layout));
+  });
+
+  it('round-trips with loadLayout', () => {
+    const layout: ResourceCardLayout = { rows: [['bandwidth'], ['cpu', 'ram']] };
+    persistLayout(layout);
+    expect(loadLayout()).toEqual(layout);
+  });
+});

--- a/apps/web/src/hooks/useResourceCardLayout.ts
+++ b/apps/web/src/hooks/useResourceCardLayout.ts
@@ -1,0 +1,57 @@
+import { useState, useCallback } from 'react';
+
+export type CardId = 'cpu' | 'ram' | 'bandwidth';
+
+export interface ResourceCardLayout {
+  rows: CardId[][];
+}
+
+export const STORAGE_KEY = 'tracearr_resource_card_layout';
+export const VALID_IDS = new Set<CardId>(['cpu', 'ram', 'bandwidth']);
+
+export const DEFAULT_LAYOUT: ResourceCardLayout = {
+  rows: [['cpu', 'ram', 'bandwidth']],
+};
+
+export function loadLayout(): ResourceCardLayout {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return DEFAULT_LAYOUT;
+
+    const parsed = JSON.parse(stored) as ResourceCardLayout;
+    if (!Array.isArray(parsed.rows)) return DEFAULT_LAYOUT;
+
+    const allIds = parsed.rows.flat();
+
+    if (
+      parsed.rows.every((row) => Array.isArray(row) && row.length > 0) &&
+      allIds.length === 3 &&
+      allIds.every((id) => VALID_IDS.has(id)) &&
+      new Set(allIds).size === 3
+    ) {
+      return parsed;
+    }
+  } catch {
+    // ignore
+  }
+  return DEFAULT_LAYOUT;
+}
+
+export function persistLayout(layout: ResourceCardLayout) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(layout));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+export function useResourceCardLayout() {
+  const [layout, setLayoutState] = useState<ResourceCardLayout>(loadLayout);
+
+  const setLayout = useCallback((next: ResourceCardLayout) => {
+    persistLayout(next);
+    setLayoutState(next);
+  }, []);
+
+  return { layout, setLayout };
+}

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -6,8 +6,7 @@ import { StatCard } from '@/components/ui/stat-card';
 import { NowPlayingCard } from '@/components/sessions';
 import { StreamCard } from '@/components/map';
 import { SessionDetailSheet } from '@/components/history/SessionDetailSheet';
-import { ServerResourceCharts } from '@/components/charts/ServerResourceCharts';
-import { ServerBandwidthChart } from '@/components/charts/BandwidthChart';
+import { DraggableResourceCards } from '@/components/charts/DraggableResourceCards';
 import { useDashboardStats, useActiveSessions } from '@/hooks/queries';
 import { useServerStatistics, useServerBandwidth } from '@/hooks/queries/useServers';
 import { useServer } from '@/hooks/useServer';
@@ -170,20 +169,16 @@ export function Dashboard() {
             <Activity className="text-primary h-5 w-5" />
             <h2 className="text-lg font-semibold">{t('dashboard.serverResources')}</h2>
           </div>
-          <ServerResourceCharts
-            data={serverStats?.data}
-            isLoading={statsChartLoading}
-            averages={averages}
+          <DraggableResourceCards
+            resourceData={serverStats?.data}
+            resourceLoading={statsChartLoading}
+            resourceAverages={averages}
+            bandwidthData={bandwidthStats?.data}
+            bandwidthLoading={bandwidthChartLoading}
+            bandwidthAverages={bandwidthAverages}
+            bandwidthPollInterval={bandwidthPollInterval}
+            onBandwidthPollIntervalChange={setBandwidthPollInterval}
           />
-          <div className="mt-4">
-            <ServerBandwidthChart
-              data={bandwidthStats?.data}
-              isLoading={bandwidthChartLoading}
-              averages={bandwidthAverages}
-              pollInterval={bandwidthPollInterval}
-              onPollIntervalChange={setBandwidthPollInterval}
-            />
-          </div>
         </section>
       )}
 


### PR DESCRIPTION
## Summary

Replaces the static CPU/RAM/Bandwidth chart grid on the dashboard with draggable, reorderable resource cards.

`dnd-kit` was already a requirement, but seemingly not used anywhere - so no new deps.

Card order persists across sessions via localStorage for now, as per previous features.

The cards are now responsive, moving to rows of their own as the canvas gets smaller or viewed on Mobile (browser, not app).

Added basic tests.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Breaking change

## Related Issue

None

## Changes

- Added `DraggableResourceCards` component using `@dnd-kit/core` for drag-and-drop reordering of CPU, RAM, and Bandwidth cards
- Added `useResourceCardLayout` hook to persist card row layout to localStorage with validation on load
- Exported `ResourceChart` from `ServerResourceCharts` and removed the `ServerResourceCharts` wrapper (card composition now handled by the draggable container)
- Updated `Dashboard.tsx` to use the new unified `DraggableResourceCards` instead of separate `ServerResourceCharts` + `ServerBandwidthChart`
- Replaced manual y-axis max calculation in `BandwidthChart` with Highcharts `softMax` for cleaner scaling
- Custom collision detection prioritizes card drop targets over row gap zones when the pointer is directly over a card
- Cards flex responsively based on how many share a row (1/3, 1/2, or full width)

## Screenshots

Before:
<img width="2235" height="670" alt="Screenshot from 2026-02-25 12-25-03" src="https://github.com/user-attachments/assets/12824331-d065-4681-9af5-a9d4fa69cf15" />

Mid drag:
<img width="2235" height="822" alt="Screenshot from 2026-02-25 12-24-53" src="https://github.com/user-attachments/assets/dda90530-9597-422c-80cc-79694485a20e" />

After:
<img width="2235" height="429" alt="Screenshot from 2026-02-25 12-25-13" src="https://github.com/user-attachments/assets/0908ff39-d96b-416a-8b7d-8bdd780d06cd" />



## Testing

- [x] Added/updated unit tests
- [X] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Tests added for `computeNewLayout`, `getFlexBasis`, `findCardRowInLayout` (layout helpers) and `loadLayout`/`persistLayout` (localStorage round-tripping and validation edge cases).

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [X] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [X] No new warnings from `pnpm typecheck`
- [X] Tests pass locally
