### PR TITLE
Fix .dockerignore to exclude all node_modules directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # Dependencies - will be installed fresh in container
-node_modules
+**/node_modules
 .pnpm-store
 
 # Turbo cache - not needed in Docker build


### PR DESCRIPTION
## Summary

Fix `.dockerignore` to exclude all `node_modules` directories, not just the root. After the dependency update in 33154431, pnpm workspace subdirectory `node_modules` started leaking into the Docker build context via `COPY . .`, overwriting pnpm's freshly-created symlinks and breaking `tsc` type resolution.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

None

## Changes

- Changed `.dockerignore` pattern from `node_modules` to `**/node_modules` so all workspace subdirectory `node_modules` are excluded from the build context

## Testing

- [ ] Added/updated unit tests
- [ ] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Verified the Docker build (`Dockerfile.supervised`) completes successfully with the `**/node_modules` pattern. Previously failed with `TS2688: Cannot find type definition file for 'vite/client'` when building locally (CI was unaffected since clean checkouts have no subdirectory `node_modules`).

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
