### PR TITLE
Comment all tailscale exit node code, until proxy support comes

### DIFF
--- a/apps/server/src/routes/tailscale.ts
+++ b/apps/server/src/routes/tailscale.ts
@@ -3,7 +3,8 @@
  */
 
 import type { FastifyPluginAsync } from 'fastify';
-import { tailscaleEnableSchema, tailscaleExitNodeSchema } from '@tracearr/shared';
+// Exit node disabled — this will come back when we implement SOCKS proxy support
+import { tailscaleEnableSchema /* , tailscaleExitNodeSchema */ } from '@tracearr/shared';
 import { tailscaleService } from '../services/tailscale.js';
 
 export const tailscaleRoutes: FastifyPluginAsync = async (app) => {
@@ -40,17 +41,17 @@ export const tailscaleRoutes: FastifyPluginAsync = async (app) => {
     return { logs: tailscaleService.getLogs() };
   });
 
-  /**
-   * POST /tailscale/exit-node — Set or clear the exit node
-   */
-  app.post('/exit-node', { preHandler: [app.requireOwner] }, async (request, reply) => {
-    const body = tailscaleExitNodeSchema.safeParse(request.body);
-    if (!body.success) {
-      return reply.badRequest('Invalid request body');
-    }
-
-    return tailscaleService.setExitNode(body.data.id ?? null);
-  });
+  // Exit node disabled — this will come back when we implement SOCKS proxy support
+  // /**
+  //  * POST /tailscale/exit-node — Set or clear the exit node
+  //  */
+  // app.post('/exit-node', { preHandler: [app.requireOwner] }, async (request, reply) => {
+  //   const body = tailscaleExitNodeSchema.safeParse(request.body);
+  //   if (!body.success) {
+  //     return reply.badRequest('Invalid request body');
+  //   }
+  //   return tailscaleService.setExitNode(body.data.id ?? null);
+  // });
 
   /**
    * POST /tailscale/reset — Wipe all state (machine identity, auth) for a fresh start

--- a/apps/server/src/services/tailscale.ts
+++ b/apps/server/src/services/tailscale.ts
@@ -107,26 +107,22 @@ class TailscaleService {
     return this.getInfo();
   }
 
-  /**
-   * Set or clear the exit node
-   */
-  async setExitNode(id: string | null): Promise<TailscaleInfo> {
-    if (this.status !== 'connected') {
-      return this.getInfo();
-    }
-
-    const exitNodeArg = id ? (this.exitNodes.find((n) => n.id === id)?.hostname ?? id) : '';
-
-    await execFileAsync(
-      TAILSCALE_BIN,
-      [`--socket=${SOCKET_FILE}`, 'set', `--exit-node=${exitNodeArg}`],
-      { env: TAILSCALE_ENV }
-    );
-
-    await this.persistState();
-    await this.refreshStatus();
-    return this.getInfo();
-  }
+  // Exit node disabled — this will come back when we implement SOCKS proxy support
+  //
+  // async setExitNode(id: string | null): Promise<TailscaleInfo> {
+  //   if (this.status !== 'connected') {
+  //     return this.getInfo();
+  //   }
+  //   const exitNodeArg = id ? (this.exitNodes.find((n) => n.id === id)?.hostname ?? id) : '';
+  //   await execFileAsync(
+  //     TAILSCALE_BIN,
+  //     [`--socket=${SOCKET_FILE}`, 'set', `--exit-node=${exitNodeArg}`],
+  //     { env: TAILSCALE_ENV }
+  //   );
+  //   await this.persistState();
+  //   await this.refreshStatus();
+  //   return this.getInfo();
+  // }
 
   /**
    * Called on startup — reads DB settings, starts daemon if previously enabled

--- a/apps/web/src/components/settings/TailscaleSettings.tsx
+++ b/apps/web/src/components/settings/TailscaleSettings.tsx
@@ -8,13 +8,14 @@ import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+// Exit node disabled — this will come back when we implement SOCKS proxy support
+// import {
+//   Select,
+//   SelectContent,
+//   SelectItem,
+//   SelectTrigger,
+//   SelectValue,
+// } from '@/components/ui/select';
 import {
   Loader2,
   ExternalLink,
@@ -30,7 +31,7 @@ import {
   useTailscaleLogs,
   useEnableTailscale,
   useDisableTailscale,
-  useSetExitNode,
+  // useSetExitNode, // Exit node disabled — will come back with SOCKS proxy support
   useResetTailscale,
 } from '@/hooks/queries';
 
@@ -58,7 +59,7 @@ export function TailscaleSettings() {
   const enableMutation = useEnableTailscale();
   const disableMutation = useDisableTailscale();
   const resetMutation = useResetTailscale();
-  const exitNodeMutation = useSetExitNode();
+  // const exitNodeMutation = useSetExitNode();
   const [hostname, setHostname] = useState('');
   const [showDisableConfirm, setShowDisableConfirm] = useState(false);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
@@ -269,7 +270,8 @@ export function TailscaleSettings() {
                       </td>
                     </tr>
                   )}
-                  {status.exitNodes.length > 0 && (
+                  {/* Exit node disabled — this will come back when we implement SOCKS proxy support */}
+                  {/* {status.exitNodes.length > 0 && (
                     <tr>
                       <td className="text-muted-foreground py-1.5 pr-4 align-top">Exit Node</td>
                       <td className="py-1.5">
@@ -299,7 +301,7 @@ export function TailscaleSettings() {
                         </Select>
                       </td>
                     </tr>
-                  )}
+                  )} */}
                 </tbody>
               </table>
 

--- a/apps/web/src/hooks/queries/index.ts
+++ b/apps/web/src/hooks/queries/index.ts
@@ -122,7 +122,7 @@ export {
   useTailscaleLogs,
   useEnableTailscale,
   useDisableTailscale,
-  useSetExitNode,
+  // useSetExitNode, // Exit node disabled — will come back with SOCKS proxy support
   useResetTailscale,
 } from './useTailscale';
 

--- a/apps/web/src/hooks/queries/useTailscale.ts
+++ b/apps/web/src/hooks/queries/useTailscale.ts
@@ -69,21 +69,22 @@ export function useDisableTailscale() {
   });
 }
 
-export function useSetExitNode() {
-  const { t } = useTranslation('settings');
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (id: string | null) => api.tailscale.setExitNode(id),
-    onSuccess: (data) => {
-      queryClient.setQueryData<TailscaleInfo>(['tailscale', 'status'], data);
-      toast.success(t('tailscale.toast.exitNodeSet'));
-    },
-    onError: (err) => {
-      toast.error(t('tailscale.toast.exitNodeFailed'), { description: err.message });
-    },
-  });
-}
+// Exit node disabled — this will come back when we implement SOCKS proxy support
+//
+// export function useSetExitNode() {
+//   const { t } = useTranslation('settings');
+//   const queryClient = useQueryClient();
+//   return useMutation({
+//     mutationFn: (id: string | null) => api.tailscale.setExitNode(id),
+//     onSuccess: (data) => {
+//       queryClient.setQueryData<TailscaleInfo>(['tailscale', 'status'], data);
+//       toast.success(t('tailscale.toast.exitNodeSet'));
+//     },
+//     onError: (err) => {
+//       toast.error(t('tailscale.toast.exitNodeFailed'), { description: err.message });
+//     },
+//   });
+// }
 
 export function useResetTailscale() {
   const { t } = useTranslation('settings');

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1570,11 +1570,12 @@ class ApiClient {
     disable: () =>
       this.request<TailscaleInfo>('/tailscale/disable', { method: 'POST', body: '{}' }),
     reset: () => this.request<TailscaleInfo>('/tailscale/reset', { method: 'POST', body: '{}' }),
-    setExitNode: (id: string | null) =>
-      this.request<TailscaleInfo>('/tailscale/exit-node', {
-        method: 'POST',
-        body: JSON.stringify({ id }),
-      }),
+    // Exit node disabled — this will come back when we implement SOCKS proxy support
+    // setExitNode: (id: string | null) =>
+    //   this.request<TailscaleInfo>('/tailscale/exit-node', {
+    //     method: 'POST',
+    //     body: JSON.stringify({ id }),
+    //   }),
     getLogs: () => this.request<{ logs: string }>('/tailscale/logs'),
   };
 


### PR DESCRIPTION
## Summary

Disable the Tailscale exit node feature across the full stack. Userspace networking mode doesn't support exit nodes, so this comments out all exit node code (API route, service method, UI, hooks, API client) rather than removing it - it will come back when we implement outbound SOCKS proxy support - if and when we choose to do that.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Breaking change

## Related Issue

N/A

## Changes

- Commented out `POST /tailscale/exit-node` API route and `tailscaleExitNodeSchema` import
- Commented out `setExitNode()` method in the Tailscale service
- Commented out `setExitNode` in the frontend API client
- Commented out `useSetExitNode` React Query hook and its barrel export
- Commented out exit node `<Select>` dropdown and related imports in `TailscaleSettings`
- Shared types/schemas (`TailscaleExitNode`, `tailscaleExitNodeSchema`) left in place as harmless exports
- Exit node data parsing in `refreshStatus()` left in place (just reads peer info, no side effects)

## Screenshots

N/A - the exit node dropdown only appeared when connected to a tailnet with exit nodes configured, and it's now hidden.

## Testing

- [ ] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Verified all exit node code paths are commented out across server routes, service, API client, hooks, and UI. The `POST /tailscale/exit-node` endpoint no longer registers.

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
