### PR TITLE
Add more to .dockerignore to fix dirty containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,12 +2,17 @@
 **/node_modules
 .pnpm-store
 
-# Turbo cache - not needed in Docker build
-.turbo
+# Turbo cache - not needed in Docker build (root + per-package)
+**/.turbo
+
+# Build artifacts - must be rebuilt fresh in container
+**/dist
+**/*.tsbuildinfo
 
 # Git
 .git
 .gitignore
+.husky/
 
 # IDE and editor files
 .idea
@@ -16,8 +21,28 @@
 *.swo
 .DS_Store
 
+# Test files and directories
+apps/e2e/
+apps/server/test/
+**/__tests__/
+**/*.test.ts
+**/*.test.tsx
+**/*.spec.ts
+**/*.spec.tsx
+
 # Testing artifacts
-coverage
+**/coverage
+
+# Dev tooling config
+.editorconfig
+.prettierrc
+.prettierignore
+.lintstagedrc.json
+.tool-versions
+eslint.config.js
+tsconfig.eslint.json
+codecov.yml
+crowdin.yml
 
 # Logs
 *.log
@@ -33,8 +58,9 @@ pnpm-debug.log*
 docker-compose*.yml
 .dockerignore
 
-# Documentation (not needed in image)
+# Documentation
 docs/
+*.md
 
 # CI/CD
 .github/


### PR DESCRIPTION
## Summary

Following the last set of .dockerignore additions, i was still having local container build issues until I added these.


## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

N/A

Closes #

## Changes

Critical (causing stale cache / broken builds):
- `**/dist` — prevents stale local build artifacts from leaking into the container
- `**/.turbo` — was only excluding root, now catches per-package caches
- `**/*.tsbuildinfo` — TypeScript incremental build cache

Test files (not needed for build or runtime):
- `apps/e2e/` — entire Playwright e2e app (~5.8 MB)
- `apps/server/test/` — integration test directory
- `**/__tests__/`, `**/*.test.ts`, `**/*.test.tsx`, `**/*.spec.ts` — all test files. Verified no production code imports from these.

Dev tooling (not needed for build):
- `.husky/` — git hooks
- `.editorconfig`, `.prettierrc`, `.prettierignore`, `.lintstagedrc.json` — formatting
- `.tool-versions` — asdf version manager
- `eslint.config.js`, `tsconfig.eslint.json` — linting
- `codecov.yml`, `crowdin.yml` — CI service configs

Docs:
- `*.md` — catches README, CONTRIBUTING, RELEASE_NOTES, etc.

Fixed:
- `coverage` → `**/coverage` — catches per-package coverage dirs too

## Screenshots

<!-- For UI changes. Delete this section otherwise. -->

## Testing

- [ ] Added/updated unit tests
- [ ] Ran test suite locally (`pnpm test:unit`)
- [X] Tested manually

<!-- If manual testing, describe what you did: -->

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [X] Tests pass locally
