### PR TITLE
Fix for #544: Language Settings Not Saved

### DIFF
--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -1,11 +1,9 @@
-import { initI18n, type SupportedLanguage, supportedLanguages } from '@tracearr/translations';
-
-// Initialize i18n with browser language detection
-const userLanguage = navigator.language.split('-')[0] as SupportedLanguage;
-const language: SupportedLanguage = supportedLanguages.includes(userLanguage) ? userLanguage : 'en';
+import { initI18n, detectLanguage, type SupportedLanguage } from '@tracearr/translations';
 
 // Export the ready promise so main.tsx can await before rendering.
-// This ensures non-English locale data is loaded before the first paint.
-export const i18nReady = initI18n({ lng: language });
+// detectLanguage() checks stored preference first, then browser language, then falls back to English.
+export const i18nReady = detectLanguage().then((language) =>
+  initI18n({ lng: language as SupportedLanguage })
+);
 
 export { i18n } from '@tracearr/translations';


### PR DESCRIPTION
## Summary

The language setting in Settings > Application > Language was not persisting across page reloads.

Root cause: i18n.ts was hardcoding `navigator.language` (browser language) during initialization, ignoring the user's saved preference in localStorage.

What changed: Replaced the manual `navigator.language` detection with the existing `detectLanguage()` function from `@tracearr/translations`, which already has the correct priority:

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

Closes #544

## Changes

- Replaced manual `navigator.language` detection in `apps/web/src/i18n.ts` with the existing `detectLanguage()` function from `@tracearr/translations`
- `detectLanguage()` already implements the correct priority: stored localStorage preference -> browser language -> fallback to English
- The `changeLanguage()` function was already saving to localStorage correctly - the bug was that initialization never read it back

## Screenshots

N/A

## Testing

- [ ] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Steps to reproduce fix:
1. Go to Settings > Application > Language
2. Select a language different from browser language
3. Reload the page
4. Language setting and UI should now persist

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
