### PR TITLE
DB settings table change

### DIFF
--- a/apps/server/src/db/migrations/0057_large_iron_monger.sql
+++ b/apps/server/src/db/migrations/0057_large_iron_monger.sql
@@ -1,0 +1,78 @@
+-- Settings KV migration: convert from wide singleton table to key-value store
+-- Safe order: create new → copy data → drop old → rename new
+
+CREATE TABLE "settings_new" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "settings_new_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"name" varchar(255) NOT NULL,
+	"value" jsonb,
+	CONSTRAINT "settings_new_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+
+-- Migrate existing settings from the old singleton row into KV pairs.
+-- NULL columns are excluded (the service layer handles defaults for missing keys).
+INSERT INTO "settings_new" ("name", "value")
+SELECT name, value FROM (
+  SELECT 'allowGuestAccess' AS name, to_jsonb(allow_guest_access) AS value FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'unitSystem', to_jsonb(unit_system) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'discordWebhookUrl', to_jsonb(discord_webhook_url) FROM settings WHERE id = 1 AND discord_webhook_url IS NOT NULL
+  UNION ALL
+  SELECT 'customWebhookUrl', to_jsonb(custom_webhook_url) FROM settings WHERE id = 1 AND custom_webhook_url IS NOT NULL
+  UNION ALL
+  SELECT 'webhookFormat', to_jsonb(webhook_format) FROM settings WHERE id = 1 AND webhook_format IS NOT NULL
+  UNION ALL
+  SELECT 'ntfyTopic', to_jsonb(ntfy_topic) FROM settings WHERE id = 1 AND ntfy_topic IS NOT NULL
+  UNION ALL
+  SELECT 'ntfyAuthToken', to_jsonb(ntfy_auth_token) FROM settings WHERE id = 1 AND ntfy_auth_token IS NOT NULL
+  UNION ALL
+  SELECT 'pushoverUserKey', to_jsonb(pushover_user_key) FROM settings WHERE id = 1 AND pushover_user_key IS NOT NULL
+  UNION ALL
+  SELECT 'pushoverApiToken', to_jsonb(pushover_api_token) FROM settings WHERE id = 1 AND pushover_api_token IS NOT NULL
+  UNION ALL
+  SELECT 'pollerEnabled', to_jsonb(poller_enabled) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'pollerIntervalMs', to_jsonb(poller_interval_ms) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'usePlexGeoip', to_jsonb(use_plex_geoip) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'tautulliUrl', to_jsonb(tautulli_url) FROM settings WHERE id = 1 AND tautulli_url IS NOT NULL
+  UNION ALL
+  SELECT 'tautulliApiKey', to_jsonb(tautulli_api_key) FROM settings WHERE id = 1 AND tautulli_api_key IS NOT NULL
+  UNION ALL
+  SELECT 'externalUrl', to_jsonb(external_url) FROM settings WHERE id = 1 AND external_url IS NOT NULL
+  UNION ALL
+  SELECT 'trustProxy', to_jsonb(trust_proxy) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'mobileEnabled', to_jsonb(mobile_enabled) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'primaryAuthMethod', to_jsonb(primary_auth_method) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'tailscaleEnabled', to_jsonb(tailscale_enabled) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'tailscaleState', to_jsonb(tailscale_state) FROM settings WHERE id = 1 AND tailscale_state IS NOT NULL
+  UNION ALL
+  SELECT 'tailscaleHostname', to_jsonb(tailscale_hostname) FROM settings WHERE id = 1 AND tailscale_hostname IS NOT NULL
+  UNION ALL
+  SELECT 'backupScheduleType', to_jsonb(backup_schedule_type) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'backupScheduleTime', to_jsonb(backup_schedule_time) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'backupScheduleDayOfWeek', to_jsonb(backup_schedule_day_of_week) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'backupScheduleDayOfMonth', to_jsonb(backup_schedule_day_of_month) FROM settings WHERE id = 1
+  UNION ALL
+  SELECT 'backupRetentionCount', to_jsonb(backup_retention_count) FROM settings WHERE id = 1
+) AS migrated
+ON CONFLICT ("name") DO NOTHING;
+--> statement-breakpoint
+
+DROP TABLE "settings" CASCADE;
+--> statement-breakpoint
+
+ALTER TABLE "settings_new" RENAME TO "settings";
+--> statement-breakpoint
+ALTER SEQUENCE "settings_new_id_seq" RENAME TO "settings_id_seq";
+--> statement-breakpoint
+ALTER TABLE "settings" RENAME CONSTRAINT "settings_new_name_unique" TO "settings_name_unique";

--- a/apps/server/src/db/migrations/meta/0057_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0057_snapshot.json
@@ -1,0 +1,3240 @@
+{
+  "id": "b7294d3f-b93c-4e16-9f7d-49904e014abb",
+  "prevId": "b59ad2a8-6b16-496c-9921-45bfd070bc30",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.library_items": {
+      "name": "library_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_key": {
+          "name": "rating_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_resolution": {
+          "name": "video_resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_codec": {
+          "name": "video_codec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_codec": {
+          "name": "audio_codec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_channels": {
+          "name": "audio_channels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grandparent_title": {
+          "name": "grandparent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grandparent_rating_key": {
+          "name": "grandparent_rating_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_rating_key": {
+          "name": "parent_rating_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_index": {
+          "name": "parent_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_library_items_imdb_partial": {
+          "name": "idx_library_items_imdb_partial",
+          "columns": [
+            {
+              "expression": "imdb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"library_items\".\"imdb_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_library_items_tmdb_partial": {
+          "name": "idx_library_items_tmdb_partial",
+          "columns": [
+            {
+              "expression": "tmdb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"library_items\".\"tmdb_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_library_items_tvdb_partial": {
+          "name": "idx_library_items_tvdb_partial",
+          "columns": [
+            {
+              "expression": "tvdb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"library_items\".\"tvdb_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_library_items_server_library": {
+          "name": "idx_library_items_server_library",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_items_server_rating_key_unique": {
+          "name": "library_items_server_rating_key_unique",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_library_items_server_media_type": {
+          "name": "idx_library_items_server_media_type",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_library_items_server_created": {
+          "name": "idx_library_items_server_created",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_library_items_title_trgm": {
+          "name": "idx_library_items_title_trgm",
+          "columns": [
+            {
+              "expression": "\"title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_items_server_id_servers_id_fk": {
+          "name": "library_items_server_id_servers_id_fk",
+          "tableFrom": "library_items",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_snapshots": {
+      "name": "library_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_time": {
+          "name": "snapshot_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_size": {
+          "name": "total_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_count": {
+          "name": "movie_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "season_count": {
+          "name": "season_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "show_count": {
+          "name": "show_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "music_count": {
+          "name": "music_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "count_4k": {
+          "name": "count_4k",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "count_1080p": {
+          "name": "count_1080p",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "count_720p": {
+          "name": "count_720p",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "count_sd": {
+          "name": "count_sd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hevc_count": {
+          "name": "hevc_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h264_count": {
+          "name": "h264_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "av1_count": {
+          "name": "av1_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrichment_pending": {
+          "name": "enrichment_pending",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrichment_complete": {
+          "name": "enrichment_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "library_snapshots_server_library_time_idx": {
+          "name": "library_snapshots_server_library_time_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_snapshots_time_idx": {
+          "name": "library_snapshots_time_idx",
+          "columns": [
+            {
+              "expression": "snapshot_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_snapshots_server_id_servers_id_fk": {
+          "name": "library_snapshots_server_id_servers_id_fk",
+          "tableFrom": "library_snapshots",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mobile_sessions": {
+      "name": "mobile_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expo_push_token": {
+          "name": "expo_push_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_secret": {
+          "name": "device_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mobile_sessions_user_idx": {
+          "name": "mobile_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_sessions_device_id_idx": {
+          "name": "mobile_sessions_device_id_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_sessions_refresh_token_idx": {
+          "name": "mobile_sessions_refresh_token_idx",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_sessions_expo_push_token_idx": {
+          "name": "mobile_sessions_expo_push_token_idx",
+          "columns": [
+            {
+              "expression": "expo_push_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mobile_sessions_user_id_users_id_fk": {
+          "name": "mobile_sessions_user_id_users_id_fk",
+          "tableFrom": "mobile_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mobile_sessions_refresh_token_hash_unique": {
+          "name": "mobile_sessions_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refresh_token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mobile_tokens": {
+      "name": "mobile_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mobile_tokens_created_by_users_id_fk": {
+          "name": "mobile_tokens_created_by_users_id_fk",
+          "tableFrom": "mobile_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mobile_tokens_token_hash_unique": {
+          "name": "mobile_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channel_routing": {
+      "name": "notification_channel_routing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_enabled": {
+          "name": "discord_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "webhook_enabled": {
+          "name": "webhook_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "push_enabled": {
+          "name": "push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "web_toast_enabled": {
+          "name": "web_toast_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_channel_routing_event_type_idx": {
+          "name": "notification_channel_routing_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_channel_routing_event_type_unique": {
+          "name": "notification_channel_routing_event_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["event_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mobile_session_id": {
+          "name": "mobile_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "push_enabled": {
+          "name": "push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "on_violation_detected": {
+          "name": "on_violation_detected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "on_stream_started": {
+          "name": "on_stream_started",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "on_stream_stopped": {
+          "name": "on_stream_stopped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "on_concurrent_streams": {
+          "name": "on_concurrent_streams",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "on_new_device": {
+          "name": "on_new_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "on_trust_score_changed": {
+          "name": "on_trust_score_changed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "on_server_down": {
+          "name": "on_server_down",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "on_server_up": {
+          "name": "on_server_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "violation_min_severity": {
+          "name": "violation_min_severity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "violation_rule_types": {
+          "name": "violation_rule_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "max_per_minute": {
+          "name": "max_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "max_per_hour": {
+          "name": "max_per_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "quiet_hours_enabled": {
+          "name": "quiet_hours_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_timezone": {
+          "name": "quiet_hours_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "quiet_hours_override_critical": {
+          "name": "quiet_hours_override_critical",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_prefs_mobile_session_idx": {
+          "name": "notification_prefs_mobile_session_idx",
+          "columns": [
+            {
+              "expression": "mobile_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_preferences_mobile_session_id_mobile_sessions_id_fk": {
+          "name": "notification_preferences_mobile_session_id_mobile_sessions_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "mobile_sessions",
+          "columnsFrom": ["mobile_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_preferences_mobile_session_id_unique": {
+          "name": "notification_preferences_mobile_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["mobile_session_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "quiet_hours_start_format": {
+          "name": "quiet_hours_start_format",
+          "value": "\"notification_preferences\".\"quiet_hours_start\" IS NULL OR \"notification_preferences\".\"quiet_hours_start\" ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'"
+        },
+        "quiet_hours_end_format": {
+          "name": "quiet_hours_end_format",
+          "value": "\"notification_preferences\".\"quiet_hours_end\" IS NULL OR \"notification_preferences\".\"quiet_hours_end\" ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plex_accounts": {
+      "name": "plex_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plex_account_id": {
+          "name": "plex_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plex_username": {
+          "name": "plex_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plex_email": {
+          "name": "plex_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plex_thumbnail": {
+          "name": "plex_thumbnail",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plex_token": {
+          "name": "plex_token",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_login": {
+          "name": "allow_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plex_accounts_user_idx": {
+          "name": "plex_accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plex_accounts_allow_login_idx": {
+          "name": "plex_accounts_allow_login_idx",
+          "columns": [
+            {
+              "expression": "plex_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "allow_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plex_accounts_user_id_users_id_fk": {
+          "name": "plex_accounts_user_id_users_id_fk",
+          "tableFrom": "plex_accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plex_accounts_plex_account_id_unique": {
+          "name": "plex_accounts_plex_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["plex_account_id"]
+        },
+        "plex_accounts_user_plex_unique": {
+          "name": "plex_accounts_user_plex_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "plex_account_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rule_action_results": {
+      "name": "rule_action_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "violation_id": {
+          "name": "violation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rule_action_results_violation": {
+          "name": "idx_rule_action_results_violation",
+          "columns": [
+            {
+              "expression": "violation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rule_action_results_rule": {
+          "name": "idx_rule_action_results_rule",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rule_action_results_violation_id_violations_id_fk": {
+          "name": "rule_action_results_violation_id_violations_id_fk",
+          "tableFrom": "rule_action_results",
+          "tableTo": "violations",
+          "columnsFrom": ["violation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rule_action_results_rule_id_rules_id_fk": {
+          "name": "rule_action_results_rule_id_rules_id_fk",
+          "tableFrom": "rule_action_results",
+          "tableTo": "rules",
+          "columnsFrom": ["rule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rules": {
+      "name": "rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'warning'"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_user_id": {
+          "name": "server_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rules_active_idx": {
+          "name": "rules_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_server_id_idx": {
+          "name": "rules_server_id_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rules_server_user_id_idx": {
+          "name": "rules_server_user_id_idx",
+          "columns": [
+            {
+              "expression": "server_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rules_server_id_servers_id_fk": {
+          "name": "rules_server_id_servers_id_fk",
+          "tableFrom": "rules",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rules_server_user_id_server_users_id_fk": {
+          "name": "rules_server_user_id_server_users_id_fk",
+          "tableFrom": "rules",
+          "tableTo": "server_users",
+          "columnsFrom": ["server_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_users": {
+      "name": "server_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plex_account_id": {
+          "name": "plex_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumb_url": {
+          "name": "thumb_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_server_admin": {
+          "name": "is_server_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trust_score": {
+          "name": "trust_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "server_users_user_server_unique": {
+          "name": "server_users_user_server_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_users_server_external_unique": {
+          "name": "server_users_server_external_unique",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_users_user_idx": {
+          "name": "server_users_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_users_server_idx": {
+          "name": "server_users_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_users_username_idx": {
+          "name": "server_users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_users_plex_account_idx": {
+          "name": "server_users_plex_account_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plex_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_users_last_activity_idx": {
+          "name": "server_users_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "server_users_user_id_users_id_fk": {
+          "name": "server_users_user_id_users_id_fk",
+          "tableFrom": "server_users",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "server_users_server_id_servers_id_fk": {
+          "name": "server_users_server_id_servers_id_fk",
+          "tableFrom": "server_users",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.servers": {
+      "name": "servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_identifier": {
+          "name": "machine_identifier",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plex_account_id": {
+          "name": "plex_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "servers_plex_account_idx": {
+          "name": "servers_plex_account_idx",
+          "columns": [
+            {
+              "expression": "plex_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "servers_display_order_idx": {
+          "name": "servers_display_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_user_id": {
+          "name": "server_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plex_session_id": {
+          "name": "plex_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_title": {
+          "name": "media_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grandparent_title": {
+          "name": "grandparent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumb_path": {
+          "name": "thumb_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_key": {
+          "name": "rating_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_session_id": {
+          "name": "external_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_ms": {
+          "name": "total_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_ms": {
+          "name": "progress_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_paused_at": {
+          "name": "last_paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_duration_ms": {
+          "name": "paused_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watched": {
+          "name": "watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "force_stopped": {
+          "name": "force_stopped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "short_session": {
+          "name": "short_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo_city": {
+          "name": "geo_city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_region": {
+          "name": "geo_region",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_country": {
+          "name": "geo_country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_continent": {
+          "name": "geo_continent",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_postal": {
+          "name": "geo_postal",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_lat": {
+          "name": "geo_lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_lon": {
+          "name": "geo_lon",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_asn_number": {
+          "name": "geo_asn_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_asn_organization": {
+          "name": "geo_asn_organization",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product": {
+          "name": "product",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_transcode": {
+          "name": "is_transcode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "video_decision": {
+          "name": "video_decision",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_decision": {
+          "name": "audio_decision",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitrate": {
+          "name": "bitrate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_title": {
+          "name": "channel_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_identifier": {
+          "name": "channel_identifier",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_thumb": {
+          "name": "channel_thumb",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_number": {
+          "name": "track_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_number": {
+          "name": "disc_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_video_codec": {
+          "name": "source_video_codec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_video_width": {
+          "name": "source_video_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_video_height": {
+          "name": "source_video_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_audio_codec": {
+          "name": "source_audio_codec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_audio_channels": {
+          "name": "source_audio_channels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_video_codec": {
+          "name": "stream_video_codec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_audio_codec": {
+          "name": "stream_audio_codec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_video_details": {
+          "name": "source_video_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_audio_details": {
+          "name": "source_audio_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_video_details": {
+          "name": "stream_video_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_audio_details": {
+          "name": "stream_audio_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcode_info": {
+          "name": "transcode_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle_info": {
+          "name": "subtitle_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_server_user_time_idx": {
+          "name": "sessions_server_user_time_idx",
+          "columns": [
+            {
+              "expression": "server_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_server_time_idx": {
+          "name": "sessions_server_time_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_state_idx": {
+          "name": "sessions_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_external_session_idx": {
+          "name": "sessions_external_session_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_active_lookup_idx": {
+          "name": "sessions_active_lookup_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stopped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_device_idx": {
+          "name": "sessions_device_idx",
+          "columns": [
+            {
+              "expression": "server_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_reference_idx": {
+          "name": "sessions_reference_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_server_user_rating_idx": {
+          "name": "sessions_server_user_rating_idx",
+          "columns": [
+            {
+              "expression": "server_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_server_rating_idx": {
+          "name": "sessions_server_rating_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_dedup_fallback_idx": {
+          "name": "sessions_dedup_fallback_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_geo_idx": {
+          "name": "sessions_geo_idx",
+          "columns": [
+            {
+              "expression": "geo_lat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "geo_lon",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_media_type_idx": {
+          "name": "sessions_media_type_idx",
+          "columns": [
+            {
+              "expression": "media_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_transcode_idx": {
+          "name": "sessions_transcode_idx",
+          "columns": [
+            {
+              "expression": "is_transcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_platform_idx": {
+          "name": "sessions_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_server_date_ref": {
+          "name": "idx_sessions_server_date_ref",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_stale_detection_idx": {
+          "name": "sessions_stale_detection_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stopped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_server_id_servers_id_fk": {
+          "name": "sessions_server_id_servers_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_server_user_id_server_users_id_fk": {
+          "name": "sessions_server_user_id_server_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "server_users",
+          "columnsFrom": ["server_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "settings_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_name_unique": {
+          "name": "settings_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.termination_logs": {
+      "name": "termination_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_user_id": {
+          "name": "server_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "violation_id": {
+          "name": "violation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "termination_logs_session_idx": {
+          "name": "termination_logs_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "termination_logs_server_user_idx": {
+          "name": "termination_logs_server_user_idx",
+          "columns": [
+            {
+              "expression": "server_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "termination_logs_triggered_by_idx": {
+          "name": "termination_logs_triggered_by_idx",
+          "columns": [
+            {
+              "expression": "triggered_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "termination_logs_rule_idx": {
+          "name": "termination_logs_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "termination_logs_created_at_idx": {
+          "name": "termination_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "termination_logs_server_id_servers_id_fk": {
+          "name": "termination_logs_server_id_servers_id_fk",
+          "tableFrom": "termination_logs",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "termination_logs_server_user_id_server_users_id_fk": {
+          "name": "termination_logs_server_user_id_server_users_id_fk",
+          "tableFrom": "termination_logs",
+          "tableTo": "server_users",
+          "columnsFrom": ["server_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "termination_logs_triggered_by_user_id_users_id_fk": {
+          "name": "termination_logs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "termination_logs",
+          "tableTo": "users",
+          "columnsFrom": ["triggered_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "termination_logs_rule_id_rules_id_fk": {
+          "name": "termination_logs_rule_id_rules_id_fk",
+          "tableFrom": "termination_logs",
+          "tableTo": "rules",
+          "columnsFrom": ["rule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "termination_logs_violation_id_violations_id_fk": {
+          "name": "termination_logs_violation_id_violations_id_fk",
+          "tableFrom": "termination_logs",
+          "tableTo": "violations",
+          "columnsFrom": ["violation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plex_account_id": {
+          "name": "plex_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_token": {
+          "name": "api_token",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "aggregate_trust_score": {
+          "name": "aggregate_trust_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "total_violations": {
+          "name": "total_violations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_plex_account_id_idx": {
+          "name": "users_plex_account_id_idx",
+          "columns": [
+            {
+              "expression": "plex_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.violations": {
+      "name": "violations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_user_id": {
+          "name": "server_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_type": {
+          "name": "rule_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "violations_server_user_id_idx": {
+          "name": "violations_server_user_id_idx",
+          "columns": [
+            {
+              "expression": "server_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "violations_rule_id_idx": {
+          "name": "violations_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "violations_created_at_idx": {
+          "name": "violations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "violations_dedup_idx": {
+          "name": "violations_dedup_idx",
+          "columns": [
+            {
+              "expression": "server_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acknowledged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "violations_unique_active_user_session_rule": {
+          "name": "violations_unique_active_user_session_rule",
+          "columns": [
+            {
+              "expression": "server_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"violations\".\"acknowledged_at\" IS NULL AND \"violations\".\"session_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "violations_inactivity_dedup_idx": {
+          "name": "violations_inactivity_dedup_idx",
+          "columns": [
+            {
+              "expression": "server_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acknowledged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "violations_rule_id_rules_id_fk": {
+          "name": "violations_rule_id_rules_id_fk",
+          "tableFrom": "violations",
+          "tableTo": "rules",
+          "columnsFrom": ["rule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "violations_server_user_id_server_users_id_fk": {
+          "name": "violations_server_user_id_server_users_id_fk",
+          "tableFrom": "violations",
+          "tableTo": "server_users",
+          "columnsFrom": ["server_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "violations_session_id_sessions_id_fk": {
+          "name": "violations_session_id_sessions_id_fk",
+          "tableFrom": "violations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1772983237103,
       "tag": "0056_fair_rick_jones",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1772983237104,
+      "tag": "0057_large_iron_monger",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -25,7 +25,7 @@ import {
   check,
 } from 'drizzle-orm/pg-core';
 import { relations, sql } from 'drizzle-orm';
-import { MEDIA_TYPES, type BackupScheduleType, type WebhookFormat } from '@tracearr/shared';
+import { MEDIA_TYPES } from '@tracearr/shared';
 
 // Server types enum
 export const serverTypeEnum = ['plex', 'jellyfin', 'emby'] as const;
@@ -655,63 +655,11 @@ export const terminationLogs = pgTable(
 // Unit system enum for display preferences
 export const unitSystemEnum = ['metric', 'imperial'] as const;
 
-// Application settings (single row)
+// Application settings (key-value store)
 export const settings = pgTable('settings', {
-  id: integer('id').primaryKey().default(1),
-  allowGuestAccess: boolean('allow_guest_access').notNull().default(false),
-  // Display preferences
-  unitSystem: varchar('unit_system', { length: 20 })
-    .notNull()
-    .$type<(typeof unitSystemEnum)[number]>()
-    .default('metric'),
-  // Notification settings
-  discordWebhookUrl: text('discord_webhook_url'),
-  customWebhookUrl: text('custom_webhook_url'),
-  webhookFormat: text('webhook_format').$type<WebhookFormat>(), // Format for custom webhook payloads
-  ntfyTopic: text('ntfy_topic'), // Topic for ntfy notifications (required when webhookFormat is 'ntfy')
-  ntfyAuthToken: text('ntfy_auth_token'), // Auth token for protected ntfy servers (Bearer token)
-  pushoverUserKey: text('pushover_user_key'),
-  pushoverApiToken: text('pushover_api_token'),
-  // Poller settings
-  pollerEnabled: boolean('poller_enabled').notNull().default(true),
-  pollerIntervalMs: integer('poller_interval_ms').notNull().default(15000),
-  // GeoIP settings
-  usePlexGeoip: boolean('use_plex_geoip').notNull().default(false), // Use Plex API for GeoIP lookups (sends IPs to plex.tv)
-  // Tautulli integration
-  tautulliUrl: text('tautulli_url'),
-  tautulliApiKey: text('tautulli_api_key'), // Encrypted
-  // Network/access settings for self-hosted deployments
-  externalUrl: text('external_url'), // Public URL for mobile/external access (e.g., https://tracearr.example.com)
-  trustProxy: boolean('trust_proxy').notNull().default(false), // Trust X-Forwarded-* headers from reverse proxy
-  // Mobile access
-  mobileEnabled: boolean('mobile_enabled').notNull().default(false),
-  // Authentication settings
-  primaryAuthMethod: varchar('primary_auth_method', { length: 20 })
-    .$type<'jellyfin' | 'local'>()
-    .notNull()
-    .default('local'), // Default to local auth
-  // Tailscale VPN integration
-  tailscaleEnabled: boolean('tailscale_enabled').notNull().default(false),
-  tailscaleState: text('tailscale_state'), // Persisted tailscaled state blob (base64)
-  tailscaleHostname: varchar('tailscale_hostname', { length: 255 }), // Custom machine name on tailnet
-  // Backup settings
-  backupScheduleType: varchar('backup_schedule_type', { length: 20 })
-    .$type<BackupScheduleType>()
-    .notNull()
-    .default('disabled'),
-  backupScheduleTime: varchar('backup_schedule_time', { length: 5 }) // HH:MM 24h
-    .notNull()
-    .default('02:00'),
-  backupScheduleDayOfWeek: integer('backup_schedule_day_of_week') // 0=Sun..6=Sat
-    .notNull()
-    .default(0),
-  backupScheduleDayOfMonth: integer('backup_schedule_day_of_month') // 1-28
-    .notNull()
-    .default(1),
-  backupRetentionCount: integer('backup_retention_count') // How many scheduled backups to keep
-    .notNull()
-    .default(7),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+  name: varchar('name', { length: 255 }).notNull().unique(),
+  value: jsonb('value'),
 });
 
 // ============================================================================

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -66,7 +66,11 @@ import { libraryRoutes } from './routes/library.js';
 import { tailscaleRoutes } from './routes/tailscale.js';
 import { tasksRoutes } from './routes/tasks.js';
 import { backupRoutes } from './routes/backup.js';
-import { getPollerSettings, getNetworkSettings } from './routes/settings.js';
+import {
+  getPollerSettings,
+  getNetworkSettings,
+  getBackupScheduleSettings,
+} from './routes/settings.js';
 import { initializeEncryption, migrateToken, looksEncrypted } from './utils/crypto.js';
 import { geoipService } from './services/geoip.js';
 import { tailscaleService } from './services/tailscale.js';
@@ -124,7 +128,7 @@ import { cleanupMobileTokens } from './jobs/cleanupMobileTokens.js';
 import { db, checkDatabaseConnection, runMigrations } from './db/client.js';
 import { initTimescaleDB, getTimescaleStatus, updateTimescaleExtensions } from './db/timescale.js';
 import { eq } from 'drizzle-orm';
-import { servers, settings } from './db/schema.js';
+import { servers } from './db/schema.js';
 import { initializeClaimCode } from './utils/claimCode.js';
 import { registerService, unregisterService } from './services/serviceTracker.js';
 import {
@@ -753,20 +757,8 @@ async function initializeServices(app: FastifyInstance) {
     startBackupWorker();
 
     // Read backup schedule from settings and configure repeatable job
-    const backupSettings = await db
-      .select({
-        type: settings.backupScheduleType,
-        time: settings.backupScheduleTime,
-        dayOfWeek: settings.backupScheduleDayOfWeek,
-        dayOfMonth: settings.backupScheduleDayOfMonth,
-      })
-      .from(settings)
-      .where(eq(settings.id, 1))
-      .limit(1);
-
-    if (backupSettings[0]) {
-      await scheduleBackupJob(backupSettings[0]);
-    }
+    const backupSchedule = await getBackupScheduleSettings();
+    await scheduleBackupJob(backupSchedule);
 
     app.log.info('Backup queue initialized');
   } catch (err) {

--- a/apps/server/src/jobs/backupQueue.ts
+++ b/apps/server/src/jobs/backupQueue.ts
@@ -6,16 +6,13 @@
  */
 
 import { Queue, Worker, type Job, type ConnectionOptions } from 'bullmq';
-import { eq } from 'drizzle-orm';
 import { getRedisPrefix } from '@tracearr/shared';
 import type { BackupScheduleType } from '@tracearr/shared';
 import { isMaintenance } from '../serverState.js';
-import { db } from '../db/client.js';
-import { settings } from '../db/schema.js';
+import { getSetting } from '../services/settings.js';
 import { BACKUP_DIR, createBackup, cleanupOldBackups } from '../services/backup.js';
 
 const QUEUE_NAME = 'backup';
-const SETTINGS_ID = 1;
 
 let connectionOptions: ConnectionOptions | null = null;
 let backupQueue: Queue | null = null;
@@ -71,13 +68,7 @@ export function startBackupWorker(): void {
       console.log(`[Backup] Backup created: ${filePath} (v${metadata.app.version})`);
 
       // Read retention count from settings
-      const row = await db
-        .select({ retentionCount: settings.backupRetentionCount })
-        .from(settings)
-        .where(eq(settings.id, SETTINGS_ID))
-        .limit(1);
-
-      const retentionCount = row[0]?.retentionCount ?? 7;
+      const retentionCount = await getSetting('backupRetentionCount');
       const deleted = await cleanupOldBackups(retentionCount);
 
       if (deleted > 0) {

--- a/apps/server/src/routes/__tests__/debug.test.ts
+++ b/apps/server/src/routes/__tests__/debug.test.ts
@@ -124,17 +124,6 @@ function mockDbSelectUsers(users: { id: string }[]) {
   } as never);
 }
 
-/**
- * Create a mock for db.update()
- */
-function mockDbUpdate() {
-  vi.mocked(db.update).mockReturnValue({
-    set: vi.fn().mockReturnValue({
-      where: vi.fn().mockResolvedValue(undefined),
-    }),
-  } as never);
-}
-
 describe('Debug Routes', () => {
   let app: FastifyInstance;
   const ownerUser = createOwnerUser();
@@ -498,9 +487,6 @@ describe('Debug Routes', () => {
       // Mock all delete operations
       vi.mocked(db.delete).mockReturnValue(Promise.resolve() as never);
 
-      // Mock update for settings reset
-      mockDbUpdate();
-
       const response = await app.inject({
         method: 'POST',
         url: '/debug/reset',
@@ -511,13 +497,10 @@ describe('Debug Routes', () => {
       expect(body.success).toBe(true);
       expect(body.message).toContain('Factory reset complete');
 
-      // Verify delete was called 14 times (violations, terminationLogs, sessions, rules,
+      // Verify delete was called 15 times (violations, terminationLogs, sessions, rules,
       // notificationChannelRouting, notificationPreferences, mobileSessions, mobileTokens,
-      // librarySnapshots, libraryItems, serverUsers, servers, plexAccounts, users)
-      expect(db.delete).toHaveBeenCalledTimes(14);
-
-      // Verify settings update was called
-      expect(db.update).toHaveBeenCalled();
+      // librarySnapshots, libraryItems, serverUsers, servers, plexAccounts, users, settings)
+      expect(db.delete).toHaveBeenCalledTimes(15);
     });
   });
 

--- a/apps/server/src/routes/__tests__/mobile-beta-mode.test.ts
+++ b/apps/server/src/routes/__tests__/mobile-beta-mode.test.ts
@@ -36,9 +36,16 @@ vi.mock('../../services/termination.js', () => ({
   terminateSession: vi.fn(),
 }));
 
+// Mock settings service (mobile.ts uses getSetting/setSetting)
+vi.mock('../../services/settings.js', () => ({
+  getSetting: vi.fn(),
+  setSetting: vi.fn(),
+}));
+
 // Import mocked db and routes
 import { db } from '../../db/client.js';
 import { mobileRoutes } from '../mobile.js';
+import { getSetting, setSetting as _setSetting } from '../../services/settings.js';
 
 // Mock Redis
 const mockRedis = {
@@ -126,6 +133,8 @@ describe('Mobile Routes - Beta Mode Enabled', () => {
     vi.mocked(db.update).mockReset();
     vi.mocked(db.delete).mockReset();
     vi.mocked(db.transaction).mockReset();
+    vi.mocked(getSetting).mockReset();
+    vi.mocked(_setSetting).mockReset();
     mockRedis.get.mockReset();
     mockRedis.set.mockReset();
     mockRedis.setex.mockReset();
@@ -482,11 +491,7 @@ describe('Mobile Routes - Beta Mode Enabled', () => {
     it('generates tokens with 100 year expiry', async () => {
       app = await buildTestApp(ownerUser);
 
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ mobileEnabled: true }]),
-        }),
-      } as never);
+      vi.mocked(getSetting).mockResolvedValue(true);
 
       mockRedis.eval.mockResolvedValue(1);
 
@@ -532,11 +537,7 @@ describe('Mobile Routes - Beta Mode Enabled', () => {
     it('allows generating tokens even at device limit', async () => {
       app = await buildTestApp(ownerUser);
 
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ mobileEnabled: true }]),
-        }),
-      } as never);
+      vi.mocked(getSetting).mockResolvedValue(true);
 
       mockRedis.eval.mockResolvedValue(1);
 

--- a/apps/server/src/routes/__tests__/mobile.test.ts
+++ b/apps/server/src/routes/__tests__/mobile.test.ts
@@ -42,10 +42,17 @@ vi.mock('../../services/termination.js', () => ({
   terminateSession: vi.fn(),
 }));
 
+// Mock settings service (mobile.ts uses getSetting/setSetting)
+vi.mock('../../services/settings.js', () => ({
+  getSetting: vi.fn(),
+  setSetting: vi.fn(),
+}));
+
 // Import mocked db, routes, and termination service
 import { db } from '../../db/client.js';
 import { mobileRoutes } from '../mobile.js';
 import { terminateSession } from '../../services/termination.js';
+import { getSetting, setSetting } from '../../services/settings.js';
 
 // Mock Redis
 const mockRedis = {
@@ -230,6 +237,8 @@ describe('Mobile Routes', () => {
     vi.mocked(db.delete).mockReset();
     vi.mocked(db.transaction).mockReset();
     vi.mocked(terminateSession).mockReset();
+    vi.mocked(getSetting).mockReset();
+    vi.mocked(setSetting).mockReset();
     mockRedis.get.mockReset();
     mockRedis.set.mockReset();
     mockRedis.setex.mockReset();
@@ -258,23 +267,19 @@ describe('Mobile Routes', () => {
         createMockSession({ id: randomUUID(), deviceName: 'Pixel 8', platform: 'android' }),
       ];
 
+      // Mock getSetting for mobileEnabled
+      vi.mocked(getSetting).mockResolvedValue(true);
+
       // Mock db.select chains
       let selectCallCount = 0;
       vi.mocked(db.select).mockImplementation(() => {
         selectCallCount++;
         if (selectCallCount === 1) {
-          // Settings query
-          return {
-            from: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([{ mobileEnabled: true }]),
-            }),
-          } as never;
-        } else if (selectCallCount === 2) {
           // Sessions query
           return {
             from: vi.fn().mockResolvedValue(mockSessions),
           } as never;
-        } else if (selectCallCount === 3) {
+        } else if (selectCallCount === 2) {
           // Pending tokens count
           return {
             from: vi.fn().mockReturnValue({
@@ -321,18 +326,15 @@ describe('Mobile Routes', () => {
     it('returns empty sessions when none exist', async () => {
       app = await buildTestApp(ownerUser);
 
+      // Mock getSetting for mobileEnabled
+      vi.mocked(getSetting).mockResolvedValue(false);
+
       let selectCallCount = 0;
       vi.mocked(db.select).mockImplementation(() => {
         selectCallCount++;
         if (selectCallCount === 1) {
-          return {
-            from: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([{ mobileEnabled: false }]),
-            }),
-          } as never;
-        } else if (selectCallCount === 2) {
           return { from: vi.fn().mockResolvedValue([]) } as never;
-        } else if (selectCallCount === 3) {
+        } else if (selectCallCount === 2) {
           return {
             from: vi.fn().mockReturnValue({
               where: vi.fn().mockResolvedValue([{ count: 0 }]),
@@ -363,11 +365,7 @@ describe('Mobile Routes', () => {
     it('enables mobile access for owner', async () => {
       app = await buildTestApp(ownerUser);
 
-      vi.mocked(db.update).mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined),
-        }),
-      } as never);
+      vi.mocked(setSetting).mockResolvedValue(undefined);
 
       let selectCallCount = 0;
       vi.mocked(db.select).mockImplementation(() => {
@@ -391,7 +389,7 @@ describe('Mobile Routes', () => {
       expect(response.statusCode).toBe(200);
       const body = response.json();
       expect(body.isEnabled).toBe(true);
-      expect(db.update).toHaveBeenCalled();
+      expect(setSetting).toHaveBeenCalledWith('mobileEnabled', true);
     });
 
     it('rejects non-owner access with 403', async () => {
@@ -413,11 +411,7 @@ describe('Mobile Routes', () => {
       app = await buildTestApp(ownerUser);
 
       // Mock settings check
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ mobileEnabled: true }]),
-        }),
-      } as never);
+      vi.mocked(getSetting).mockResolvedValue(true);
 
       // Mock rate limit check (Redis eval)
       mockRedis.eval.mockResolvedValue(1);
@@ -452,11 +446,7 @@ describe('Mobile Routes', () => {
     it('rejects when mobile not enabled', async () => {
       app = await buildTestApp(ownerUser);
 
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ mobileEnabled: false }]),
-        }),
-      } as never);
+      vi.mocked(getSetting).mockResolvedValue(false);
 
       const response = await app.inject({
         method: 'POST',
@@ -471,11 +461,7 @@ describe('Mobile Routes', () => {
     it('rejects when rate limited', async () => {
       app = await buildTestApp(ownerUser);
 
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ mobileEnabled: true }]),
-        }),
-      } as never);
+      vi.mocked(getSetting).mockResolvedValue(true);
 
       mockRedis.eval.mockResolvedValue(4); // Exceeds limit of 3
       mockRedis.ttl.mockResolvedValue(120);
@@ -505,11 +491,7 @@ describe('Mobile Routes', () => {
     it('rejects when max pending tokens reached', async () => {
       app = await buildTestApp(ownerUser);
 
-      vi.mocked(db.select).mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ mobileEnabled: true }]),
-        }),
-      } as never);
+      vi.mocked(getSetting).mockResolvedValue(true);
 
       mockRedis.eval.mockResolvedValue(1);
 
@@ -542,11 +524,7 @@ describe('Mobile Routes', () => {
 
       const mockSessions = [createMockSession()];
 
-      vi.mocked(db.update).mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined),
-        }),
-      } as never);
+      vi.mocked(setSetting).mockResolvedValue(undefined);
 
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockResolvedValue(mockSessions),
@@ -564,7 +542,7 @@ describe('Mobile Routes', () => {
       expect(response.statusCode).toBe(200);
       const body = response.json();
       expect(body.success).toBe(true);
-      expect(db.update).toHaveBeenCalled();
+      expect(setSetting).toHaveBeenCalledWith('mobileEnabled', false);
       expect(db.delete).toHaveBeenCalled();
       expect(mockRedis.del).toHaveBeenCalled();
     });
@@ -1762,11 +1740,7 @@ describe('Mobile Routes', () => {
       it('token generation uses 15 minute expiry', async () => {
         app = await buildTestApp(ownerUser);
 
-        vi.mocked(db.select).mockReturnValue({
-          from: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{ mobileEnabled: true }]),
-          }),
-        } as never);
+        vi.mocked(getSetting).mockResolvedValue(true);
 
         mockRedis.eval.mockResolvedValue(1);
 

--- a/apps/server/src/routes/__tests__/settings.test.ts
+++ b/apps/server/src/routes/__tests__/settings.test.ts
@@ -6,53 +6,78 @@
  * - PATCH /settings - Update application settings (owner only)
  */
 
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import sensible from '@fastify/sensible';
 import { randomUUID } from 'node:crypto';
-import type { AuthUser } from '@tracearr/shared';
+import type { AuthUser, Settings } from '@tracearr/shared';
 
-// Mock the database module before importing routes
+// Mock the settings service
+vi.mock('../../services/settings.js', () => ({
+  getAllSettings: vi.fn(),
+  setSettings: vi.fn(),
+  getSettings: vi.fn(),
+  getSetting: vi.fn(),
+  getPollerSettings: vi.fn(),
+  getGeoIPSettings: vi.fn(),
+  getNetworkSettings: vi.fn(),
+  getNotificationSettings: vi.fn(),
+  getBackupScheduleSettings: vi.fn(),
+}));
+
+// Mock the database module (still needed for api-key and ip-warning routes)
 vi.mock('../../db/client.js', () => ({
   db: {
     select: vi.fn(),
-    insert: vi.fn(),
     update: vi.fn(),
+    selectDistinct: vi.fn(),
   },
 }));
 
-// Import mocked modules
-import { db } from '../../db/client.js';
+// Mock notification manager
+vi.mock('../../services/notifications/index.js', () => ({
+  notificationManager: {
+    testAgent: vi.fn(),
+  },
+}));
+
+// Mock geoip service
+vi.mock('../../services/geoip.js', () => ({
+  geoipService: {
+    isPrivateIP: vi.fn(),
+  },
+}));
+
+import { getAllSettings, setSettings } from '../../services/settings.js';
 import { settingsRoutes } from '../settings.js';
 
-// Helper to create DB chain mocks
-function mockDbSelectLimit(result: unknown[]) {
-  const chain = {
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockResolvedValue(result),
-  };
-  vi.mocked(db.select).mockReturnValue(chain as never);
-  return chain;
-}
-
-function mockDbInsert(result: unknown[]) {
-  const chain = {
-    values: vi.fn().mockReturnThis(),
-    returning: vi.fn().mockResolvedValue(result),
-  };
-  vi.mocked(db.insert).mockReturnValue(chain as never);
-  return chain;
-}
-
-function mockDbUpdate() {
-  const chain = {
-    set: vi.fn().mockReturnThis(),
-    where: vi.fn().mockResolvedValue(undefined),
-  };
-  vi.mocked(db.update).mockReturnValue(chain as never);
-  return chain;
-}
+const mockAllSettings: Settings = {
+  allowGuestAccess: false,
+  unitSystem: 'metric',
+  discordWebhookUrl: 'https://discord.com/api/webhooks/123',
+  customWebhookUrl: 'https://example.com/webhook',
+  webhookFormat: 'json',
+  ntfyTopic: null,
+  ntfyAuthToken: null,
+  pushoverUserKey: null,
+  pushoverApiToken: null,
+  pollerEnabled: true,
+  pollerIntervalMs: 15000,
+  usePlexGeoip: false,
+  tautulliUrl: 'http://localhost:8181',
+  tautulliApiKey: 'secret-api-key',
+  externalUrl: 'https://tracearr.example.com',
+  trustProxy: true,
+  mobileEnabled: false,
+  primaryAuthMethod: 'local',
+  tailscaleEnabled: false,
+  tailscaleHostname: null,
+  backupScheduleType: 'disabled',
+  backupScheduleTime: '02:00',
+  backupScheduleDayOfWeek: 0,
+  backupScheduleDayOfMonth: 1,
+  backupRetentionCount: 7,
+};
 
 async function buildTestApp(authUser: AuthUser): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
@@ -80,27 +105,13 @@ const viewerUser: AuthUser = {
   serverIds: [],
 };
 
-const mockSettingsRow = {
-  id: 1,
-  allowGuestAccess: false,
-  discordWebhookUrl: 'https://discord.com/api/webhooks/123',
-  customWebhookUrl: 'https://example.com/webhook',
-  webhookFormat: 'json' as const,
-  ntfyTopic: null,
-  ntfyAuthToken: null,
-  pollerEnabled: true,
-  pollerIntervalMs: 15000,
-  tautulliUrl: 'http://localhost:8181',
-  tautulliApiKey: 'secret-api-key',
-  externalUrl: 'https://tracearr.example.com',
-  trustProxy: true,
-  mobileEnabled: false,
-  createdAt: new Date(),
-  updatedAt: new Date(),
-};
-
 describe('Settings Routes', () => {
   let app: FastifyInstance;
+
+  beforeEach(() => {
+    vi.mocked(getAllSettings).mockResolvedValue({ ...mockAllSettings });
+    vi.mocked(setSettings).mockResolvedValue(undefined);
+  });
 
   afterEach(async () => {
     await app?.close();
@@ -110,8 +121,6 @@ describe('Settings Routes', () => {
   describe('GET /settings', () => {
     it('returns settings for owner', async () => {
       app = await buildTestApp(ownerUser);
-
-      mockDbSelectLimit([mockSettingsRow]);
 
       const response = await app.inject({
         method: 'GET',
@@ -128,10 +137,8 @@ describe('Settings Routes', () => {
       expect(body.trustProxy).toBe(true);
     });
 
-    it('masks tautulli API key in response', async () => {
+    it('returns tautulli API key to owners', async () => {
       app = await buildTestApp(ownerUser);
-
-      mockDbSelectLimit([mockSettingsRow]);
 
       const response = await app.inject({
         method: 'GET',
@@ -140,14 +147,16 @@ describe('Settings Routes', () => {
 
       expect(response.statusCode).toBe(200);
       const body = response.json();
-      expect(body.tautulliApiKey).toBe('********');
+      expect(body.tautulliApiKey).toBe('secret-api-key');
       expect(body.tautulliUrl).toBe('http://localhost:8181');
     });
 
     it('returns null for tautulliApiKey when not set', async () => {
       app = await buildTestApp(ownerUser);
-
-      mockDbSelectLimit([{ ...mockSettingsRow, tautulliApiKey: null }]);
+      vi.mocked(getAllSettings).mockResolvedValue({
+        ...mockAllSettings,
+        tautulliApiKey: null,
+      });
 
       const response = await app.inject({
         method: 'GET',
@@ -159,39 +168,7 @@ describe('Settings Routes', () => {
       expect(body.tautulliApiKey).toBe(null);
     });
 
-    it('creates default settings when none exist', async () => {
-      app = await buildTestApp(ownerUser);
-
-      // First select returns empty (no settings)
-      mockDbSelectLimit([]);
-
-      // Then insert creates defaults
-      const defaultSettings = {
-        id: 1,
-        allowGuestAccess: false,
-        discordWebhookUrl: null,
-        customWebhookUrl: null,
-        pollerEnabled: true,
-        pollerIntervalMs: 15000,
-        tautulliUrl: null,
-        tautulliApiKey: null,
-        externalUrl: null,
-        trustProxy: false,
-        mobileEnabled: false,
-      };
-      mockDbInsert([defaultSettings]);
-
-      const response = await app.inject({
-        method: 'GET',
-        url: '/settings',
-      });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.allowGuestAccess).toBe(false);
-    });
-
-    it('rejects guest accessing settings', async () => {
+    it('rejects viewer accessing settings', async () => {
       app = await buildTestApp(viewerUser);
 
       const response = await app.inject({
@@ -205,8 +182,11 @@ describe('Settings Routes', () => {
 
     it('returns webhook format settings', async () => {
       app = await buildTestApp(ownerUser);
-
-      mockDbSelectLimit([{ ...mockSettingsRow, webhookFormat: 'ntfy', ntfyTopic: 'my-topic' }]);
+      vi.mocked(getAllSettings).mockResolvedValue({
+        ...mockAllSettings,
+        webhookFormat: 'ntfy',
+        ntfyTopic: 'my-topic',
+      });
 
       const response = await app.inject({
         method: 'GET',
@@ -218,71 +198,97 @@ describe('Settings Routes', () => {
       expect(body.webhookFormat).toBe('ntfy');
       expect(body.ntfyTopic).toBe('my-topic');
     });
+
+    it('returns ntfy auth token to owners', async () => {
+      app = await buildTestApp(ownerUser);
+      vi.mocked(getAllSettings).mockResolvedValue({
+        ...mockAllSettings,
+        ntfyAuthToken: 'tk_secret_token_456',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/settings',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.ntfyAuthToken).toBe('tk_secret_token_456');
+    });
+
+    it('returns null for ntfy auth token when not set', async () => {
+      app = await buildTestApp(ownerUser);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/settings',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.ntfyAuthToken).toBe(null);
+    });
+
+    it('returns pushover api token to owners', async () => {
+      app = await buildTestApp(ownerUser);
+      vi.mocked(getAllSettings).mockResolvedValue({
+        ...mockAllSettings,
+        pushoverApiToken: 'pushover-api-token',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/settings',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.pushoverApiToken).toBe('pushover-api-token');
+    });
+
+    it('returns null for pushover api token when not set', async () => {
+      app = await buildTestApp(ownerUser);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/settings',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.pushoverApiToken).toBe(null);
+    });
   });
 
   describe('PATCH /settings', () => {
     it('updates settings for owner', async () => {
       app = await buildTestApp(ownerUser);
 
-      // First check existing settings
-      mockDbSelectLimit([mockSettingsRow]);
-      mockDbUpdate();
-
-      // Return updated settings on final select
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi
-            .fn()
-            .mockResolvedValue(
-              selectCount === 1
-                ? [mockSettingsRow]
-                : [{ ...mockSettingsRow, allowGuestAccess: true }]
-            ),
-        };
-        return chain as never;
+      // After setSettings, getAllSettings returns updated values
+      vi.mocked(getAllSettings).mockResolvedValue({
+        ...mockAllSettings,
+        allowGuestAccess: true,
       });
 
       const response = await app.inject({
         method: 'PATCH',
         url: '/settings',
-        payload: {
-          allowGuestAccess: true,
-        },
+        payload: { allowGuestAccess: true },
       });
 
       expect(response.statusCode).toBe(200);
+      expect(setSettings).toHaveBeenCalledWith({ allowGuestAccess: true });
       const body = response.json();
       expect(body.allowGuestAccess).toBe(true);
     });
 
     it('updates webhook URLs', async () => {
       app = await buildTestApp(ownerUser);
-
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [mockSettingsRow]
-              : [
-                  {
-                    ...mockSettingsRow,
-                    discordWebhookUrl: 'https://new-discord-webhook.com',
-                    customWebhookUrl: 'https://new-custom-webhook.com',
-                  },
-                ]
-          ),
-        };
-        return chain as never;
+      vi.mocked(getAllSettings).mockResolvedValue({
+        ...mockAllSettings,
+        discordWebhookUrl: 'https://new-discord-webhook.com',
+        customWebhookUrl: 'https://new-custom-webhook.com',
       });
-      mockDbUpdate();
 
       const response = await app.inject({
         method: 'PATCH',
@@ -301,36 +307,16 @@ describe('Settings Routes', () => {
 
     it('updates poller settings', async () => {
       app = await buildTestApp(ownerUser);
-
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [mockSettingsRow]
-              : [
-                  {
-                    ...mockSettingsRow,
-                    pollerEnabled: false,
-                    pollerIntervalMs: 30000,
-                  },
-                ]
-          ),
-        };
-        return chain as never;
+      vi.mocked(getAllSettings).mockResolvedValue({
+        ...mockAllSettings,
+        pollerEnabled: false,
+        pollerIntervalMs: 30000,
       });
-      mockDbUpdate();
 
       const response = await app.inject({
         method: 'PATCH',
         url: '/settings',
-        payload: {
-          pollerEnabled: false,
-          pollerIntervalMs: 30000,
-        },
+        payload: { pollerEnabled: false, pollerIntervalMs: 30000 },
       });
 
       expect(response.statusCode).toBe(200);
@@ -339,131 +325,50 @@ describe('Settings Routes', () => {
       expect(body.pollerIntervalMs).toBe(30000);
     });
 
-    it('updates tautulli settings', async () => {
+    it('normalizes externalUrl by stripping trailing slash', async () => {
       app = await buildTestApp(ownerUser);
-
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [mockSettingsRow]
-              : [
-                  {
-                    ...mockSettingsRow,
-                    tautulliUrl: 'http://tautulli:8181',
-                    tautulliApiKey: 'new-api-key',
-                  },
-                ]
-          ),
-        };
-        return chain as never;
+      vi.mocked(getAllSettings).mockResolvedValue({
+        ...mockAllSettings,
+        externalUrl: 'https://new-url.com',
       });
-      mockDbUpdate();
 
       const response = await app.inject({
         method: 'PATCH',
         url: '/settings',
-        payload: {
-          tautulliUrl: 'http://tautulli:8181',
-          tautulliApiKey: 'new-api-key',
-        },
+        payload: { externalUrl: 'https://new-url.com/' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(setSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ externalUrl: 'https://new-url.com' })
+      );
+    });
+
+    it('returns tautulli API key in PATCH response', async () => {
+      app = await buildTestApp(ownerUser);
+      vi.mocked(getAllSettings).mockResolvedValue({
+        ...mockAllSettings,
+        tautulliApiKey: 'new-api-key',
+      });
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/settings',
+        payload: { tautulliApiKey: 'new-api-key' },
       });
 
       expect(response.statusCode).toBe(200);
       const body = response.json();
-      expect(body.tautulliUrl).toBe('http://tautulli:8181');
-      expect(body.tautulliApiKey).toBe('********'); // Should be masked
+      expect(body.tautulliApiKey).toBe('new-api-key');
     });
 
-    it('updates network settings and normalizes externalUrl', async () => {
-      app = await buildTestApp(ownerUser);
-
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [mockSettingsRow]
-              : [
-                  {
-                    ...mockSettingsRow,
-                    externalUrl: 'https://new-url.com', // Should strip trailing slash
-                    trustProxy: false,
-                  },
-                ]
-          ),
-        };
-        return chain as never;
-      });
-      mockDbUpdate();
-
-      const response = await app.inject({
-        method: 'PATCH',
-        url: '/settings',
-        payload: {
-          externalUrl: 'https://new-url.com/', // With trailing slash
-          trustProxy: false,
-        },
-      });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.externalUrl).toBe('https://new-url.com');
-      expect(body.trustProxy).toBe(false);
-    });
-
-    it('creates settings when none exist', async () => {
-      app = await buildTestApp(ownerUser);
-
-      // First select returns empty (no settings)
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [] // No existing settings
-              : [{ ...mockSettingsRow, allowGuestAccess: true }] // After insert
-          ),
-        };
-        return chain as never;
-      });
-
-      const insertChain = {
-        values: vi.fn().mockResolvedValue(undefined),
-      };
-      vi.mocked(db.insert).mockReturnValue(insertChain as never);
-
-      const response = await app.inject({
-        method: 'PATCH',
-        url: '/settings',
-        payload: {
-          allowGuestAccess: true,
-        },
-      });
-
-      expect(response.statusCode).toBe(200);
-      expect(db.insert).toHaveBeenCalled();
-    });
-
-    it('rejects guest updating settings', async () => {
+    it('rejects viewer updating settings', async () => {
       app = await buildTestApp(viewerUser);
 
       const response = await app.inject({
         method: 'PATCH',
         url: '/settings',
-        payload: {
-          allowGuestAccess: true,
-        },
+        payload: { allowGuestAccess: true },
       });
 
       expect(response.statusCode).toBe(403);
@@ -476,153 +381,10 @@ describe('Settings Routes', () => {
       const response = await app.inject({
         method: 'PATCH',
         url: '/settings',
-        payload: {
-          pollerIntervalMs: 'not-a-number', // Should be number
-        },
+        payload: { pollerIntervalMs: 'not-a-number' },
       });
 
       expect(response.statusCode).toBe(400);
-    });
-
-    it('handles empty update body', async () => {
-      app = await buildTestApp(ownerUser);
-
-      vi.mocked(db.select).mockImplementation(() => {
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue([mockSettingsRow]),
-        };
-        return chain as never;
-      });
-      mockDbUpdate();
-
-      const response = await app.inject({
-        method: 'PATCH',
-        url: '/settings',
-        payload: {},
-      });
-
-      expect(response.statusCode).toBe(200);
-      // Should still update the updatedAt timestamp
-      expect(db.update).toHaveBeenCalled();
-    });
-
-    it('clears webhook URLs when set to null', async () => {
-      app = await buildTestApp(ownerUser);
-
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [mockSettingsRow]
-              : [
-                  {
-                    ...mockSettingsRow,
-                    discordWebhookUrl: null,
-                    customWebhookUrl: null,
-                  },
-                ]
-          ),
-        };
-        return chain as never;
-      });
-      mockDbUpdate();
-
-      const response = await app.inject({
-        method: 'PATCH',
-        url: '/settings',
-        payload: {
-          discordWebhookUrl: null,
-          customWebhookUrl: null,
-        },
-      });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.discordWebhookUrl).toBe(null);
-      expect(body.customWebhookUrl).toBe(null);
-    });
-
-    it('updates webhook format to ntfy', async () => {
-      app = await buildTestApp(ownerUser);
-
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [mockSettingsRow]
-              : [
-                  {
-                    ...mockSettingsRow,
-                    webhookFormat: 'ntfy',
-                    ntfyTopic: 'tracearr-alerts',
-                  },
-                ]
-          ),
-        };
-        return chain as never;
-      });
-      mockDbUpdate();
-
-      const response = await app.inject({
-        method: 'PATCH',
-        url: '/settings',
-        payload: {
-          webhookFormat: 'ntfy',
-          ntfyTopic: 'tracearr-alerts',
-        },
-      });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.webhookFormat).toBe('ntfy');
-      expect(body.ntfyTopic).toBe('tracearr-alerts');
-    });
-
-    it('updates webhook format to apprise', async () => {
-      app = await buildTestApp(ownerUser);
-
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [mockSettingsRow]
-              : [
-                  {
-                    ...mockSettingsRow,
-                    webhookFormat: 'apprise',
-                  },
-                ]
-          ),
-        };
-        return chain as never;
-      });
-      mockDbUpdate();
-
-      const response = await app.inject({
-        method: 'PATCH',
-        url: '/settings',
-        payload: {
-          webhookFormat: 'apprise',
-        },
-      });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.webhookFormat).toBe('apprise');
     });
 
     it('rejects invalid webhook format', async () => {
@@ -631,388 +393,42 @@ describe('Settings Routes', () => {
       const response = await app.inject({
         method: 'PATCH',
         url: '/settings',
-        payload: {
-          webhookFormat: 'invalid-format',
-        },
+        payload: { webhookFormat: 'invalid-format' },
       });
 
       expect(response.statusCode).toBe(400);
     });
 
-    it('clears ntfy topic when set to null', async () => {
+    it('clears webhook URLs when set to null', async () => {
       app = await buildTestApp(ownerUser);
-
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [{ ...mockSettingsRow, ntfyTopic: 'old-topic' }]
-              : [
-                  {
-                    ...mockSettingsRow,
-                    ntfyTopic: null,
-                  },
-                ]
-          ),
-        };
-        return chain as never;
+      vi.mocked(getAllSettings).mockResolvedValue({
+        ...mockAllSettings,
+        discordWebhookUrl: null,
+        customWebhookUrl: null,
       });
-      mockDbUpdate();
 
       const response = await app.inject({
         method: 'PATCH',
         url: '/settings',
-        payload: {
-          ntfyTopic: null,
-        },
+        payload: { discordWebhookUrl: null, customWebhookUrl: null },
       });
 
       expect(response.statusCode).toBe(200);
       const body = response.json();
-      expect(body.ntfyTopic).toBe(null);
+      expect(body.discordWebhookUrl).toBe(null);
+      expect(body.customWebhookUrl).toBe(null);
     });
 
-    it('updates ntfy auth token', async () => {
+    it('handles empty update body', async () => {
       app = await buildTestApp(ownerUser);
-
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [mockSettingsRow]
-              : [
-                  {
-                    ...mockSettingsRow,
-                    webhookFormat: 'ntfy',
-                    ntfyTopic: 'tracearr',
-                    ntfyAuthToken: 'tk_secret_token_123',
-                  },
-                ]
-          ),
-        };
-        return chain as never;
-      });
-      mockDbUpdate();
 
       const response = await app.inject({
         method: 'PATCH',
         url: '/settings',
-        payload: {
-          webhookFormat: 'ntfy',
-          ntfyTopic: 'tracearr',
-          ntfyAuthToken: 'tk_secret_token_123',
-        },
+        payload: {},
       });
 
       expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.webhookFormat).toBe('ntfy');
-      expect(body.ntfyTopic).toBe('tracearr');
-      // Auth token should be masked in response
-      expect(body.ntfyAuthToken).toBe('********');
     });
-
-    it('masks ntfy auth token in GET response', async () => {
-      app = await buildTestApp(ownerUser);
-
-      mockDbSelectLimit([
-        {
-          ...mockSettingsRow,
-          webhookFormat: 'ntfy',
-          ntfyTopic: 'my-topic',
-          ntfyAuthToken: 'tk_secret_token_456',
-        },
-      ]);
-
-      const response = await app.inject({
-        method: 'GET',
-        url: '/settings',
-      });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.ntfyAuthToken).toBe('********');
-    });
-
-    it('returns null for ntfy auth token when not set', async () => {
-      app = await buildTestApp(ownerUser);
-
-      mockDbSelectLimit([
-        {
-          ...mockSettingsRow,
-          webhookFormat: 'ntfy',
-          ntfyTopic: 'my-topic',
-          ntfyAuthToken: null,
-        },
-      ]);
-
-      const response = await app.inject({
-        method: 'GET',
-        url: '/settings',
-      });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.ntfyAuthToken).toBe(null);
-    });
-
-    it('clears ntfy auth token when set to null', async () => {
-      app = await buildTestApp(ownerUser);
-
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [{ ...mockSettingsRow, ntfyAuthToken: 'tk_old_token' }]
-              : [
-                  {
-                    ...mockSettingsRow,
-                    ntfyAuthToken: null,
-                  },
-                ]
-          ),
-        };
-        return chain as never;
-      });
-      mockDbUpdate();
-
-      const response = await app.inject({
-        method: 'PATCH',
-        url: '/settings',
-        payload: {
-          ntfyAuthToken: null,
-        },
-      });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.ntfyAuthToken).toBe(null);
-    });
-
-    it('updates webhook format to pushover', async () => {
-      app = await buildTestApp(ownerUser);
-
-      let selectCount = 0;
-      vi.mocked(db.select).mockImplementation(() => {
-        selectCount++;
-        const chain = {
-          from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnThis(),
-          limit: vi.fn().mockResolvedValue(
-            selectCount === 1
-              ? [mockSettingsRow]
-              : [
-                  {
-                    ...mockSettingsRow,
-                    webhookFormat: 'pushover',
-                    pushoverUserKey: 'pushover-user-key',
-                    pushoverApiToken: 'pushover-api-token',
-                  },
-                ]
-          ),
-        };
-        return chain as never;
-      });
-      mockDbUpdate();
-
-      const response = await app.inject({
-        method: 'PATCH',
-        url: '/settings',
-        payload: {
-          webhookFormat: 'pushover',
-          pushoverUserKey: 'pushover-user-key',
-          pushoverApiToken: 'pushover-api-token',
-        },
-      });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body.webhookFormat).toBe('pushover');
-      expect(body.pushoverUserKey).toBe('pushover-user-key');
-      expect(body.pushoverApiToken).toBe('********');
-    });
-  });
-
-  it('clears pushover fields when set to null', async () => {
-    app = await buildTestApp(ownerUser);
-
-    let selectCount = 0;
-    vi.mocked(db.select).mockImplementation(() => {
-      selectCount++;
-      const chain = {
-        from: vi.fn().mockReturnThis(),
-        where: vi.fn().mockReturnThis(),
-        limit: vi.fn().mockResolvedValue(
-          selectCount === 1
-            ? [
-                {
-                  ...mockSettingsRow,
-                  pushoverUserKey: 'pushover-user-key',
-                  pushoverApiToken: 'pushover-api-token',
-                },
-              ]
-            : [
-                {
-                  ...mockSettingsRow,
-                  pushoverUserKey: null,
-                  pushoverApiToken: null,
-                },
-              ]
-        ),
-      };
-      return chain as never;
-    });
-    mockDbUpdate();
-
-    const response = await app.inject({
-      method: 'PATCH',
-      url: '/settings',
-      payload: {
-        pushoverUserKey: null,
-        pushoverApiToken: null,
-      },
-    });
-
-    expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body.pushoverUserKey).toBe(null);
-    expect(body.pushoverApiToken).toBe(null);
-  });
-
-  it('updates pushover api token', async () => {
-    app = await buildTestApp(ownerUser);
-
-    let selectCount = 0;
-    vi.mocked(db.select).mockImplementation(() => {
-      selectCount++;
-      const chain = {
-        from: vi.fn().mockReturnThis(),
-        where: vi.fn().mockReturnThis(),
-        limit: vi.fn().mockResolvedValue(
-          selectCount === 1
-            ? [mockSettingsRow]
-            : [
-                {
-                  ...mockSettingsRow,
-                  webhookFormat: 'pushover',
-                  pushoverUserKey: 'pushover-user-key',
-                  pushoverApiToken: 'pushover-api-token',
-                },
-              ]
-        ),
-      };
-      return chain as never;
-    });
-    mockDbUpdate();
-
-    const response = await app.inject({
-      method: 'PATCH',
-      url: '/settings',
-      payload: {
-        webhookFormat: 'pushover',
-        pushoverUserKey: 'pushover-user-key',
-        pushoverApiToken: 'pushover-api-token',
-      },
-    });
-
-    expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body.webhookFormat).toBe('pushover');
-    expect(body.pushoverUserKey).toBe('pushover-user-key');
-    // API token should be masked in response
-    expect(body.pushoverApiToken).toBe('********');
-  });
-
-  it('masks pushover api token in GET response', async () => {
-    app = await buildTestApp(ownerUser);
-
-    mockDbSelectLimit([
-      {
-        ...mockSettingsRow,
-        webhookFormat: 'pushover',
-        pushoverUserKey: 'pushover-user-key',
-        pushoverApiToken: 'pushover-api-token',
-      },
-    ]);
-
-    const response = await app.inject({
-      method: 'GET',
-      url: '/settings',
-    });
-
-    expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body.pushoverApiToken).toBe('********');
-  });
-
-  it('returns null for pushover api token when not set', async () => {
-    app = await buildTestApp(ownerUser);
-
-    mockDbSelectLimit([
-      {
-        ...mockSettingsRow,
-        webhookFormat: 'pushover',
-        pushoverUserKey: 'pushover-user-key',
-        pushoverApiToken: null,
-      },
-    ]);
-
-    const response = await app.inject({
-      method: 'GET',
-      url: '/settings',
-    });
-
-    expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body.pushoverApiToken).toBe(null);
-  });
-
-  it('clears pushover api token when set to null', async () => {
-    app = await buildTestApp(ownerUser);
-
-    let selectCount = 0;
-    vi.mocked(db.select).mockImplementation(() => {
-      selectCount++;
-      const chain = {
-        from: vi.fn().mockReturnThis(),
-        where: vi.fn().mockReturnThis(),
-        limit: vi.fn().mockResolvedValue(
-          selectCount === 1
-            ? [{ ...mockSettingsRow, pushoverApiToken: 'pushover-api-token' }]
-            : [
-                {
-                  ...mockSettingsRow,
-                  pushoverApiToken: null,
-                },
-              ]
-        ),
-      };
-      return chain as never;
-    });
-    mockDbUpdate();
-
-    const response = await app.inject({
-      method: 'PATCH',
-      url: '/settings',
-      payload: {
-        pushoverApiToken: null,
-      },
-    });
-
-    expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body.pushoverApiToken).toBe(null);
   });
 });

--- a/apps/server/src/routes/backup.ts
+++ b/apps/server/src/routes/backup.ts
@@ -12,16 +12,15 @@ import { randomBytes } from 'node:crypto';
 import { stat, statfs, writeFile } from 'node:fs/promises';
 import { join, basename } from 'node:path';
 import { pipeline } from 'node:stream/promises';
-import { eq, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import { z } from 'zod';
 import type { BackupScheduleType } from '@tracearr/shared';
 import { db } from '../db/client.js';
-import { settings } from '../db/schema.js';
 import { isRestoring } from '../serverState.js';
 import { BACKUP_DIR, createBackup, validateBackup, listBackups } from '../services/backup.js';
 import { orchestrateRestore } from '../services/restoreOrchestrator.js';
 import { scheduleBackupJob } from '../jobs/backupQueue.js';
-const SETTINGS_ID = 1;
+import { getBackupScheduleSettings, setSettings } from '../services/settings.js';
 
 // Short-lived download tokens (in-memory, single use, 60s expiry)
 const DOWNLOAD_TOKEN_TTL_MS = 60_000;
@@ -317,26 +316,7 @@ export const backupRoutes: FastifyPluginAsync = async (app) => {
 
   /** GET /backup/schedule — Get current schedule settings */
   app.get('/schedule', { preHandler: [app.requireOwner] }, async () => {
-    const row = await db
-      .select({
-        type: settings.backupScheduleType,
-        time: settings.backupScheduleTime,
-        dayOfWeek: settings.backupScheduleDayOfWeek,
-        dayOfMonth: settings.backupScheduleDayOfMonth,
-        retentionCount: settings.backupRetentionCount,
-      })
-      .from(settings)
-      .where(eq(settings.id, SETTINGS_ID))
-      .limit(1);
-
-    const schedule = row[0] ?? {
-      type: 'disabled' as const,
-      time: '02:00',
-      dayOfWeek: 0,
-      dayOfMonth: 1,
-      retentionCount: 7,
-    };
-
+    const schedule = await getBackupScheduleSettings();
     return { ...schedule, timezone: process.env.TZ || 'UTC' };
   });
 
@@ -351,16 +331,13 @@ export const backupRoutes: FastifyPluginAsync = async (app) => {
 
     const { type, time, dayOfWeek, dayOfMonth, retentionCount } = parsed.data;
 
-    await db
-      .update(settings)
-      .set({
-        backupScheduleType: type as BackupScheduleType,
-        backupScheduleTime: time,
-        backupScheduleDayOfWeek: dayOfWeek,
-        backupScheduleDayOfMonth: dayOfMonth,
-        backupRetentionCount: retentionCount,
-      })
-      .where(eq(settings.id, SETTINGS_ID));
+    await setSettings({
+      backupScheduleType: type,
+      backupScheduleTime: time,
+      backupScheduleDayOfWeek: dayOfWeek,
+      backupScheduleDayOfMonth: dayOfMonth,
+      backupRetentionCount: retentionCount,
+    });
 
     // Reschedule the BullMQ repeatable job
     await scheduleBackupJob({ type: type as BackupScheduleType, time, dayOfWeek, dayOfMonth });

--- a/apps/server/src/routes/debug.ts
+++ b/apps/server/src/routes/debug.ts
@@ -364,19 +364,8 @@ export const debugRoutes: FastifyPluginAsync = async (app) => {
     await db.delete(plexAccounts); // plex_accounts references users
     await db.delete(users);
 
-    // Reset settings to defaults
-    await db
-      .update(settings)
-      .set({
-        allowGuestAccess: false,
-        discordWebhookUrl: null,
-        customWebhookUrl: null,
-        pollerEnabled: true,
-        pollerIntervalMs: 15000,
-        tautulliUrl: null,
-        tautulliApiKey: null,
-      })
-      .where(sql`id = 1`);
+    // Reset settings to defaults (KV store — just delete all rows; service uses defaults for missing keys)
+    await db.delete(settings);
 
     return {
       success: true,

--- a/apps/server/src/routes/mobile.ts
+++ b/apps/server/src/routes/mobile.ts
@@ -36,8 +36,9 @@ import {
   terminateSessionBodySchema,
 } from '@tracearr/shared';
 import { db } from '../db/client.js';
-import { mobileTokens, mobileSessions, servers, users, settings, sessions } from '../db/schema.js';
+import { mobileTokens, mobileSessions, servers, users, sessions } from '../db/schema.js';
 import { terminateSession } from '../services/termination.js';
+import { getSetting, setSetting } from '../services/settings.js';
 import { hasServerAccess } from '../utils/serverFiltering.js';
 
 // Rate limits for mobile auth endpoints
@@ -137,11 +138,7 @@ export const mobileRoutes: FastifyPluginAsync = async (app) => {
     }
 
     // Get mobile enabled status from settings
-    const settingsRow = await db
-      .select({ mobileEnabled: settings.mobileEnabled })
-      .from(settings)
-      .limit(1);
-    const isEnabled = settingsRow[0]?.mobileEnabled ?? false;
+    const isEnabled = await getSetting('mobileEnabled');
 
     // Get mobile sessions
     const sessionsRows = await db.select().from(mobileSessions);
@@ -189,10 +186,7 @@ export const mobileRoutes: FastifyPluginAsync = async (app) => {
     }
 
     // Update settings to enable mobile
-    await db
-      .update(settings)
-      .set({ mobileEnabled: true, updatedAt: new Date() })
-      .where(eq(settings.id, 1));
+    await setSetting('mobileEnabled', true);
 
     // Get current state for response
     const sessionsRows = await db.select().from(mobileSessions);
@@ -237,11 +231,7 @@ export const mobileRoutes: FastifyPluginAsync = async (app) => {
     }
 
     // Check if mobile is enabled
-    const settingsRow = await db
-      .select({ mobileEnabled: settings.mobileEnabled })
-      .from(settings)
-      .limit(1);
-    if (!settingsRow[0]?.mobileEnabled) {
+    if (!(await getSetting('mobileEnabled'))) {
       return reply.badRequest('Mobile access is not enabled');
     }
 
@@ -358,10 +348,7 @@ export const mobileRoutes: FastifyPluginAsync = async (app) => {
     }
 
     // Disable in settings
-    await db
-      .update(settings)
-      .set({ mobileEnabled: false, updatedAt: new Date() })
-      .where(eq(settings.id, 1));
+    await setSetting('mobileEnabled', false);
 
     // Revoke all mobile sessions (delete from DB and Redis)
     const sessionsRows = await db.select().from(mobileSessions);

--- a/apps/server/src/routes/settings.ts
+++ b/apps/server/src/routes/settings.ts
@@ -7,8 +7,20 @@ import { eq, sql } from 'drizzle-orm';
 import { randomBytes } from 'crypto';
 import { updateSettingsSchema, type Settings, type WebhookFormat } from '@tracearr/shared';
 import { db } from '../db/client.js';
-import { settings, users, sessions } from '../db/schema.js';
+import { users, sessions } from '../db/schema.js';
 import { geoipService } from '../services/geoip.js';
+import { notificationManager } from '../services/notifications/index.js';
+import { getAllSettings, getSettings, setSettings } from '../services/settings.js';
+
+// Re-export service getters so existing import paths still work
+export {
+  getPollerSettings,
+  getGeoIPSettings,
+  getNetworkSettings,
+  getNotificationSettings,
+  getBackupScheduleSettings,
+  type NotificationSettings,
+} from '../services/settings.js';
 
 // API token format: trr_pub_<32 random bytes as base64url>
 const API_TOKEN_PREFIX = 'trr_pub_';
@@ -17,11 +29,6 @@ function generateApiToken(): string {
   const randomPart = randomBytes(32).toString('base64url');
   return `${API_TOKEN_PREFIX}${randomPart}`;
 }
-
-import { notificationManager } from '../services/notifications/index.js';
-
-// Default settings row ID (singleton pattern)
-const SETTINGS_ID = 1;
 
 export const settingsRoutes: FastifyPluginAsync = async (app) => {
   /**
@@ -35,131 +42,7 @@ export const settingsRoutes: FastifyPluginAsync = async (app) => {
       return reply.forbidden('Only server owners can view settings');
     }
 
-    // Get or create settings
-    // First try to get settings - if primaryAuthMethod column doesn't exist, this will fail
-    let settingsRow;
-    let primaryAuthMethod: 'jellyfin' | 'local' = 'local';
-
-    try {
-      // Try full select including primaryAuthMethod
-      settingsRow = await db.select().from(settings).where(eq(settings.id, SETTINGS_ID)).limit(1);
-
-      // If we got here, column exists - extract the value
-      const row = settingsRow[0];
-      if (row && 'primaryAuthMethod' in row && row.primaryAuthMethod) {
-        primaryAuthMethod = row.primaryAuthMethod;
-      }
-    } catch {
-      // Column doesn't exist yet - select without primaryAuthMethod
-      // We need to explicitly select each column
-      settingsRow = await db
-        .select({
-          id: settings.id,
-          allowGuestAccess: settings.allowGuestAccess,
-          unitSystem: settings.unitSystem,
-          discordWebhookUrl: settings.discordWebhookUrl,
-          customWebhookUrl: settings.customWebhookUrl,
-          webhookFormat: settings.webhookFormat,
-          ntfyTopic: settings.ntfyTopic,
-          ntfyAuthToken: settings.ntfyAuthToken,
-          pushoverUserKey: settings.pushoverUserKey,
-          pushoverApiToken: settings.pushoverApiToken,
-          pollerEnabled: settings.pollerEnabled,
-          pollerIntervalMs: settings.pollerIntervalMs,
-          tautulliUrl: settings.tautulliUrl,
-          tautulliApiKey: settings.tautulliApiKey,
-          externalUrl: settings.externalUrl,
-          trustProxy: settings.trustProxy,
-          mobileEnabled: settings.mobileEnabled,
-          backupScheduleType: settings.backupScheduleType,
-          backupScheduleTime: settings.backupScheduleTime,
-          backupScheduleDayOfWeek: settings.backupScheduleDayOfWeek,
-          backupScheduleDayOfMonth: settings.backupScheduleDayOfMonth,
-          backupRetentionCount: settings.backupRetentionCount,
-          updatedAt: settings.updatedAt,
-        })
-        .from(settings)
-        .where(eq(settings.id, SETTINGS_ID))
-        .limit(1);
-      // Use default since column doesn't exist
-      primaryAuthMethod = 'local';
-    }
-
-    // Create default settings if not exists
-    if (settingsRow.length === 0) {
-      try {
-        const inserted = await db
-          .insert(settings)
-          .values({
-            id: SETTINGS_ID,
-            allowGuestAccess: false,
-            primaryAuthMethod: 'local',
-          })
-          .returning();
-        settingsRow = inserted;
-      } catch {
-        // Column doesn't exist - insert without primaryAuthMethod
-        const inserted = await db
-          .insert(settings)
-          .values({
-            id: SETTINGS_ID,
-            allowGuestAccess: false,
-          })
-          .returning();
-        settingsRow = inserted;
-      }
-    }
-
-    const row = settingsRow[0];
-    if (!row) {
-      return reply.internalServerError('Failed to load settings');
-    }
-
-    // Handle case where usePlexGeoip column might not exist yet (before migration)
-    let usePlexGeoip = false;
-    if ('usePlexGeoip' in row && typeof row.usePlexGeoip === 'boolean') {
-      usePlexGeoip = row.usePlexGeoip;
-    }
-
-    // Handle case where tailscale columns might not exist yet (before migration)
-    let tailscaleEnabled = false;
-    let tailscaleHostname: string | null = null;
-    if ('tailscaleEnabled' in row && typeof row.tailscaleEnabled === 'boolean') {
-      tailscaleEnabled = row.tailscaleEnabled;
-    }
-    if ('tailscaleHostname' in row && typeof row.tailscaleHostname === 'string') {
-      tailscaleHostname = row.tailscaleHostname;
-    }
-
-    const result: Settings = {
-      allowGuestAccess: row.allowGuestAccess,
-      unitSystem: row.unitSystem,
-      discordWebhookUrl: row.discordWebhookUrl,
-      customWebhookUrl: row.customWebhookUrl,
-      webhookFormat: row.webhookFormat,
-      ntfyTopic: row.ntfyTopic,
-      ntfyAuthToken: row.ntfyAuthToken ? '********' : null, // Mask auth token
-      pushoverUserKey: row.pushoverUserKey,
-      pushoverApiToken: row.pushoverApiToken ? '********' : null, // Mask API Token
-      pollerEnabled: row.pollerEnabled,
-      pollerIntervalMs: row.pollerIntervalMs,
-      usePlexGeoip,
-      tautulliUrl: row.tautulliUrl,
-      tautulliApiKey: row.tautulliApiKey ? '********' : null, // Mask API key
-      externalUrl: row.externalUrl,
-      trustProxy: row.trustProxy,
-      mobileEnabled: row.mobileEnabled,
-      primaryAuthMethod,
-      tailscaleEnabled,
-      tailscaleHostname,
-      backupScheduleType: row.backupScheduleType,
-      backupScheduleTime: row.backupScheduleTime,
-      backupScheduleDayOfWeek: row.backupScheduleDayOfWeek,
-      backupScheduleDayOfMonth: row.backupScheduleDayOfMonth,
-      backupRetentionCount: row.backupRetentionCount,
-    };
-
-    return result;
+    return getAllSettings();
   });
 
   /**
@@ -178,192 +61,24 @@ export const settingsRoutes: FastifyPluginAsync = async (app) => {
       return reply.forbidden('Only server owners can update settings');
     }
 
-    // Build update object
-    const updateData: Partial<{
-      allowGuestAccess: boolean;
-      unitSystem: 'metric' | 'imperial';
-      discordWebhookUrl: string | null;
-      customWebhookUrl: string | null;
-      webhookFormat: WebhookFormat | null;
-      ntfyTopic: string | null;
-      ntfyAuthToken: string | null;
-      pushoverUserKey: string | null;
-      pushoverApiToken: string | null;
-      pollerEnabled: boolean;
-      pollerIntervalMs: number;
-      usePlexGeoip: boolean;
-      tautulliUrl: string | null;
-      tautulliApiKey: string | null;
-      externalUrl: string | null;
-      trustProxy: boolean;
-      primaryAuthMethod: 'jellyfin' | 'local';
-      tailscaleHostname: string | null;
-      updatedAt: Date;
-    }> = {
-      updatedAt: new Date(),
-    };
+    // Build update object from provided fields
+    const updates: Partial<Settings> = {};
 
-    if (body.data.allowGuestAccess !== undefined) {
-      updateData.allowGuestAccess = body.data.allowGuestAccess;
+    for (const [key, value] of Object.entries(body.data)) {
+      if (value !== undefined) {
+        if (key === 'externalUrl' && typeof value === 'string') {
+          // Strip trailing slash for consistency
+          updates.externalUrl = value.replace(/\/+$/, '') || null;
+        } else {
+          (updates as Record<string, unknown>)[key] = value;
+        }
+      }
     }
 
-    if (body.data.unitSystem !== undefined) {
-      updateData.unitSystem = body.data.unitSystem;
-    }
+    await setSettings(updates);
 
-    if (body.data.discordWebhookUrl !== undefined) {
-      updateData.discordWebhookUrl = body.data.discordWebhookUrl;
-    }
-
-    if (body.data.customWebhookUrl !== undefined) {
-      updateData.customWebhookUrl = body.data.customWebhookUrl;
-    }
-
-    if (body.data.webhookFormat !== undefined) {
-      updateData.webhookFormat = body.data.webhookFormat;
-    }
-
-    if (body.data.ntfyTopic !== undefined) {
-      updateData.ntfyTopic = body.data.ntfyTopic;
-    }
-
-    if (body.data.ntfyAuthToken !== undefined) {
-      updateData.ntfyAuthToken = body.data.ntfyAuthToken;
-    }
-
-    if (body.data.pushoverUserKey !== undefined) {
-      updateData.pushoverUserKey = body.data.pushoverUserKey;
-    }
-
-    if (body.data.pushoverApiToken !== undefined) {
-      updateData.pushoverApiToken = body.data.pushoverApiToken;
-    }
-
-    if (body.data.pollerEnabled !== undefined) {
-      updateData.pollerEnabled = body.data.pollerEnabled;
-    }
-
-    if (body.data.pollerIntervalMs !== undefined) {
-      updateData.pollerIntervalMs = body.data.pollerIntervalMs;
-    }
-
-    if (body.data.usePlexGeoip !== undefined) {
-      updateData.usePlexGeoip = body.data.usePlexGeoip;
-    }
-
-    if (body.data.tautulliUrl !== undefined) {
-      updateData.tautulliUrl = body.data.tautulliUrl;
-    }
-
-    if (body.data.tautulliApiKey !== undefined) {
-      // Store API key as-is (could encrypt if needed)
-      updateData.tautulliApiKey = body.data.tautulliApiKey;
-    }
-
-    if (body.data.externalUrl !== undefined) {
-      // Strip trailing slash for consistency
-      updateData.externalUrl = body.data.externalUrl?.replace(/\/+$/, '') ?? null;
-    }
-
-    if (body.data.trustProxy !== undefined) {
-      updateData.trustProxy = body.data.trustProxy;
-    }
-
-    if (body.data.primaryAuthMethod !== undefined) {
-      updateData.primaryAuthMethod = body.data.primaryAuthMethod;
-    }
-
-    if (body.data.tailscaleHostname !== undefined) {
-      updateData.tailscaleHostname = body.data.tailscaleHostname;
-    }
-
-    // Ensure settings row exists
-    const existing = await db.select().from(settings).where(eq(settings.id, SETTINGS_ID)).limit(1);
-
-    if (existing.length === 0) {
-      // Create with provided values - use full updateData with defaults for required fields
-      // Note: mobileEnabled is not in updateData, so it will use the database default (false)
-      await db.insert(settings).values({
-        id: SETTINGS_ID,
-        allowGuestAccess: updateData.allowGuestAccess ?? false,
-        discordWebhookUrl: updateData.discordWebhookUrl ?? null,
-        customWebhookUrl: updateData.customWebhookUrl ?? null,
-        webhookFormat: updateData.webhookFormat ?? null,
-        ntfyTopic: updateData.ntfyTopic ?? null,
-        ntfyAuthToken: updateData.ntfyAuthToken ?? null,
-        pushoverUserKey: updateData.pushoverUserKey ?? null,
-        pushoverApiToken: updateData.pushoverApiToken ?? null,
-        pollerEnabled: updateData.pollerEnabled ?? true,
-        pollerIntervalMs: updateData.pollerIntervalMs ?? 15000,
-        usePlexGeoip: updateData.usePlexGeoip ?? false,
-        tautulliUrl: updateData.tautulliUrl ?? null,
-        tautulliApiKey: updateData.tautulliApiKey ?? null,
-        externalUrl: updateData.externalUrl ?? null,
-        trustProxy: updateData.trustProxy ?? false,
-        primaryAuthMethod: updateData.primaryAuthMethod ?? 'local',
-      });
-    } else {
-      // Update existing
-      await db.update(settings).set(updateData).where(eq(settings.id, SETTINGS_ID));
-    }
-
-    // Return updated settings
-    const updated = await db.select().from(settings).where(eq(settings.id, SETTINGS_ID)).limit(1);
-
-    const row = updated[0];
-    if (!row) {
-      return reply.internalServerError('Failed to update settings');
-    }
-
-    // Handle case where columns might not exist yet (before migration)
-    let primaryAuthMethod: 'jellyfin' | 'local' = 'local';
-    if ('primaryAuthMethod' in row && row.primaryAuthMethod) {
-      primaryAuthMethod = row.primaryAuthMethod;
-    }
-    let usePlexGeoip = false;
-    if ('usePlexGeoip' in row && typeof row.usePlexGeoip === 'boolean') {
-      usePlexGeoip = row.usePlexGeoip;
-    }
-
-    // Handle case where tailscale columns might not exist yet (before migration)
-    let tailscaleEnabled = false;
-    let tailscaleHostname: string | null = null;
-    if ('tailscaleEnabled' in row && typeof row.tailscaleEnabled === 'boolean') {
-      tailscaleEnabled = row.tailscaleEnabled;
-    }
-    if ('tailscaleHostname' in row && typeof row.tailscaleHostname === 'string') {
-      tailscaleHostname = row.tailscaleHostname;
-    }
-
-    const result: Settings = {
-      allowGuestAccess: row.allowGuestAccess,
-      unitSystem: row.unitSystem,
-      discordWebhookUrl: row.discordWebhookUrl,
-      customWebhookUrl: row.customWebhookUrl,
-      webhookFormat: row.webhookFormat,
-      ntfyTopic: row.ntfyTopic,
-      ntfyAuthToken: row.ntfyAuthToken ? '********' : null, // Mask auth token
-      pushoverUserKey: row.pushoverUserKey,
-      pushoverApiToken: row.pushoverApiToken ? '********' : null, // Mask API token
-      pollerEnabled: row.pollerEnabled,
-      pollerIntervalMs: row.pollerIntervalMs,
-      usePlexGeoip,
-      tautulliUrl: row.tautulliUrl,
-      tautulliApiKey: row.tautulliApiKey ? '********' : null, // Mask API key
-      externalUrl: row.externalUrl,
-      trustProxy: row.trustProxy,
-      mobileEnabled: row.mobileEnabled,
-      primaryAuthMethod,
-      tailscaleEnabled,
-      tailscaleHostname,
-      backupScheduleType: row.backupScheduleType,
-      backupScheduleTime: row.backupScheduleTime,
-      backupScheduleDayOfWeek: row.backupScheduleDayOfWeek,
-      backupScheduleDayOfMonth: row.backupScheduleDayOfMonth,
-      backupRetentionCount: row.backupRetentionCount,
-    };
-
-    return result;
+    // Return updated settings with masks
+    return getAllSettings();
   });
 
   /**
@@ -393,14 +108,16 @@ export const settingsRoutes: FastifyPluginAsync = async (app) => {
       return reply.badRequest('Missing webhook type');
     }
 
-    // Get current settings to find the URL if not provided
-    const settingsRow = await db
-      .select()
-      .from(settings)
-      .where(eq(settings.id, SETTINGS_ID))
-      .limit(1);
-
-    const currentSettings = settingsRow[0];
+    // Get current notification settings
+    const currentSettings = await getSettings([
+      'discordWebhookUrl',
+      'customWebhookUrl',
+      'webhookFormat',
+      'ntfyTopic',
+      'ntfyAuthToken',
+      'pushoverUserKey',
+      'pushoverApiToken',
+    ]);
 
     let webhookUrl: string | null = null;
     let webhookFormat: WebhookFormat = 'json';
@@ -410,14 +127,14 @@ export const settingsRoutes: FastifyPluginAsync = async (app) => {
     let pushoverApiToken: string | null = null;
 
     if (type === 'discord') {
-      webhookUrl = url ?? currentSettings?.discordWebhookUrl ?? null;
+      webhookUrl = url ?? currentSettings.discordWebhookUrl ?? null;
     } else {
-      webhookUrl = url ?? currentSettings?.customWebhookUrl ?? null;
-      webhookFormat = format ?? currentSettings?.webhookFormat ?? 'json';
-      ntfyTopic = currentSettings?.ntfyTopic ?? null;
-      ntfyAuthToken = currentSettings?.ntfyAuthToken ?? null;
-      pushoverUserKey = currentSettings?.pushoverUserKey ?? null;
-      pushoverApiToken = currentSettings?.pushoverApiToken ?? null;
+      webhookUrl = url ?? currentSettings.customWebhookUrl ?? null;
+      webhookFormat = format ?? currentSettings.webhookFormat ?? 'json';
+      ntfyTopic = currentSettings.ntfyTopic ?? null;
+      ntfyAuthToken = currentSettings.ntfyAuthToken ?? null;
+      pushoverUserKey = currentSettings.pushoverUserKey ?? null;
+      pushoverApiToken = currentSettings.pushoverApiToken ?? null;
     }
 
     if (webhookFormat === 'pushover') {
@@ -565,150 +282,3 @@ export const settingsRoutes: FastifyPluginAsync = async (app) => {
     return { showWarning, stateHash };
   });
 };
-
-/**
- * Get poller settings from database (for internal use by poller)
- */
-export async function getPollerSettings(): Promise<{ enabled: boolean; intervalMs: number }> {
-  const row = await db
-    .select({
-      pollerEnabled: settings.pollerEnabled,
-      pollerIntervalMs: settings.pollerIntervalMs,
-    })
-    .from(settings)
-    .where(eq(settings.id, SETTINGS_ID))
-    .limit(1);
-
-  const settingsRow = row[0];
-  if (!settingsRow) {
-    // Return defaults if settings don't exist yet
-    return { enabled: true, intervalMs: 15000 };
-  }
-
-  return {
-    enabled: settingsRow.pollerEnabled,
-    intervalMs: settingsRow.pollerIntervalMs,
-  };
-}
-
-/**
- * Get GeoIP settings from database (for internal use by poller/SSE processor)
- */
-export async function getGeoIPSettings(): Promise<{ usePlexGeoip: boolean }> {
-  try {
-    const row = await db
-      .select({
-        usePlexGeoip: settings.usePlexGeoip,
-      })
-      .from(settings)
-      .where(eq(settings.id, SETTINGS_ID))
-      .limit(1);
-
-    const settingsRow = row[0];
-    if (!settingsRow) {
-      // Return defaults if settings don't exist yet
-      return { usePlexGeoip: false };
-    }
-
-    return {
-      usePlexGeoip: settingsRow.usePlexGeoip,
-    };
-  } catch {
-    // Column doesn't exist yet (before migration) - use default
-    return { usePlexGeoip: false };
-  }
-}
-
-/**
- * Get network settings from database (for internal use)
- */
-export async function getNetworkSettings(): Promise<{
-  externalUrl: string | null;
-  trustProxy: boolean;
-}> {
-  const row = await db
-    .select({
-      externalUrl: settings.externalUrl,
-      trustProxy: settings.trustProxy,
-    })
-    .from(settings)
-    .where(eq(settings.id, SETTINGS_ID))
-    .limit(1);
-
-  const settingsRow = row[0];
-  if (!settingsRow) {
-    return { externalUrl: null, trustProxy: false };
-  }
-
-  return {
-    externalUrl: settingsRow.externalUrl,
-    trustProxy: settingsRow.trustProxy,
-  };
-}
-
-/**
- * Notification settings for internal use by NotificationDispatcher
- */
-export interface NotificationSettings {
-  discordWebhookUrl: string | null;
-  customWebhookUrl: string | null;
-  webhookFormat: WebhookFormat | null;
-  ntfyTopic: string | null;
-  ntfyAuthToken: string | null;
-  pushoverUserKey: string | null;
-  pushoverApiToken: string | null;
-  webhookSecret: string | null;
-  mobileEnabled: boolean;
-  unitSystem: 'metric' | 'imperial';
-}
-
-/**
- * Get notification settings from database (for internal use by notification dispatcher)
- */
-export async function getNotificationSettings(): Promise<NotificationSettings> {
-  const row = await db
-    .select({
-      discordWebhookUrl: settings.discordWebhookUrl,
-      customWebhookUrl: settings.customWebhookUrl,
-      webhookFormat: settings.webhookFormat,
-      ntfyTopic: settings.ntfyTopic,
-      ntfyAuthToken: settings.ntfyAuthToken,
-      pushoverUserKey: settings.pushoverUserKey,
-      pushoverApiToken: settings.pushoverApiToken,
-      mobileEnabled: settings.mobileEnabled,
-      unitSystem: settings.unitSystem,
-    })
-    .from(settings)
-    .where(eq(settings.id, SETTINGS_ID))
-    .limit(1);
-
-  const settingsRow = row[0];
-  if (!settingsRow) {
-    // Return defaults if settings don't exist yet
-    return {
-      discordWebhookUrl: null,
-      customWebhookUrl: null,
-      webhookFormat: null,
-      ntfyTopic: null,
-      ntfyAuthToken: null,
-      pushoverUserKey: null,
-      pushoverApiToken: null,
-      webhookSecret: null,
-      mobileEnabled: false,
-      unitSystem: 'metric',
-    };
-  }
-
-  return {
-    discordWebhookUrl: settingsRow.discordWebhookUrl,
-    customWebhookUrl: settingsRow.customWebhookUrl,
-    webhookFormat: settingsRow.webhookFormat,
-    ntfyTopic: settingsRow.ntfyTopic,
-    ntfyAuthToken: settingsRow.ntfyAuthToken,
-    pushoverUserKey: settingsRow.pushoverUserKey,
-    pushoverApiToken: settingsRow.pushoverApiToken,
-    webhookSecret: null, // TODO: Add webhookSecret column to settings table in Phase 4
-    mobileEnabled: settingsRow.mobileEnabled,
-    unitSystem: settingsRow.unitSystem,
-  };
-}

--- a/apps/server/src/routes/setup.ts
+++ b/apps/server/src/routes/setup.ts
@@ -5,8 +5,9 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { isNotNull, eq } from 'drizzle-orm';
 import { db } from '../db/client.js';
-import { servers, users, settings } from '../db/schema.js';
+import { servers, users } from '../db/schema.js';
 import { isClaimCodeEnabled } from '../utils/claimCode.js';
+import { getSetting } from '../services/settings.js';
 
 export const setupRoutes: FastifyPluginAsync = async (app) => {
   /**
@@ -30,20 +31,7 @@ export const setupRoutes: FastifyPluginAsync = async (app) => {
       db.select({ id: users.id }).from(users).where(isNotNull(users.passwordHash)).limit(1),
     ]);
 
-    // Try to get primaryAuthMethod from settings, but handle case where column doesn't exist yet
-    let primaryAuthMethod: 'jellyfin' | 'local' = 'local';
-    try {
-      const settingsRow = await db
-        .select({ primaryAuthMethod: settings.primaryAuthMethod })
-        .from(settings)
-        .limit(1);
-      if (settingsRow[0]?.primaryAuthMethod) {
-        primaryAuthMethod = settingsRow[0].primaryAuthMethod;
-      }
-    } catch {
-      // Column doesn't exist yet (migration not run) - use default
-      primaryAuthMethod = 'local';
-    }
+    const primaryAuthMethod = await getSetting('primaryAuthMethod');
 
     const needsSetup = ownerList.length === 0;
 

--- a/apps/server/src/services/settings.ts
+++ b/apps/server/src/services/settings.ts
@@ -1,0 +1,211 @@
+/**
+ * Settings service - Key-value settings abstraction layer
+ *
+ * All settings access should go through this module instead of querying
+ * the settings table directly.
+ */
+
+import { eq, inArray } from 'drizzle-orm';
+import type { Settings, WebhookFormat, UnitSystem, BackupScheduleType } from '@tracearr/shared';
+import { db } from '../db/client.js';
+import { settings } from '../db/schema.js';
+
+/** Default values for public settings (returned by GET /settings). */
+const PUBLIC_DEFAULTS: Settings = {
+  // Settings interface fields
+  allowGuestAccess: false,
+  unitSystem: 'metric',
+  discordWebhookUrl: null,
+  customWebhookUrl: null,
+  webhookFormat: null,
+  ntfyTopic: null,
+  ntfyAuthToken: null,
+  pushoverUserKey: null,
+  pushoverApiToken: null,
+  pollerEnabled: true,
+  pollerIntervalMs: 15000,
+  usePlexGeoip: false,
+  tautulliUrl: null,
+  tautulliApiKey: null,
+  externalUrl: null,
+  trustProxy: false,
+  mobileEnabled: false,
+  primaryAuthMethod: 'local',
+  tailscaleEnabled: false,
+  tailscaleHostname: null,
+  // Backup settings
+  backupScheduleType: 'disabled',
+  backupScheduleTime: '02:00',
+  backupScheduleDayOfWeek: 0,
+  backupScheduleDayOfMonth: 1,
+  backupRetentionCount: 7,
+};
+
+/**
+ * Internal-only settings — not exposed in the public Settings API.
+ * Add new internal keys here; types, defaults, and filtering are all derived.
+ */
+const INTERNAL_DEFAULTS = {
+  tailscaleState: null as string | null,
+};
+
+type InternalSettings = typeof INTERNAL_DEFAULTS;
+
+/** All settings: public + internal */
+type SettingTypes = Settings & InternalSettings;
+type SettingKey = keyof SettingTypes;
+
+/** Combined defaults — single source of truth. When a key doesn't exist in the DB, these defaults are used. */
+const ALL_DEFAULTS: SettingTypes = { ...PUBLIC_DEFAULTS, ...INTERNAL_DEFAULTS };
+
+/** Get a single setting value. Returns the stored value or the default. */
+export async function getSetting<K extends SettingKey>(key: K): Promise<SettingTypes[K]> {
+  const rows = await db
+    .select({ value: settings.value })
+    .from(settings)
+    .where(eq(settings.name, key))
+    .limit(1);
+
+  if (rows.length === 0) {
+    return ALL_DEFAULTS[key];
+  }
+
+  return rows[0]!.value as SettingTypes[K];
+}
+
+/** Get multiple settings by keys. Returns a Record with defaults applied for missing keys. */
+export async function getSettings<K extends SettingKey>(keys: K[]): Promise<Pick<SettingTypes, K>> {
+  if (keys.length === 0) return {} as Pick<SettingTypes, K>;
+
+  const rows = await db
+    .select({ name: settings.name, value: settings.value })
+    .from(settings)
+    .where(inArray(settings.name, keys));
+
+  const found = new Map(rows.map((r) => [r.name, r.value]));
+  const result = {} as Record<K, unknown>;
+
+  for (const key of keys) {
+    result[key] = found.has(key) ? found.get(key) : ALL_DEFAULTS[key];
+  }
+
+  return result as Pick<SettingTypes, K>;
+}
+
+/** All keys that make up the public Settings object. */
+const PUBLIC_KEYS = Object.keys(PUBLIC_DEFAULTS) as (keyof Settings)[];
+
+/** Get ALL settings as a typed Settings object (used by GET /settings). */
+export async function getAllSettings(): Promise<Settings> {
+  return getSettings(PUBLIC_KEYS) as Promise<Settings>;
+}
+
+/** Upsert one or more settings. */
+export async function setSettings(updates: Partial<SettingTypes>): Promise<void> {
+  const entries = Object.entries(updates);
+  if (entries.length === 0) return;
+
+  await db.transaction(async (tx) => {
+    for (const [name, value] of entries) {
+      await tx.insert(settings).values({ name, value }).onConflictDoUpdate({
+        target: settings.name,
+        set: { value },
+      });
+    }
+  });
+}
+
+/** Set a single setting. */
+export async function setSetting<K extends SettingKey>(
+  key: K,
+  value: SettingTypes[K]
+): Promise<void> {
+  await db.insert(settings).values({ name: key, value }).onConflictDoUpdate({
+    target: settings.name,
+    set: { value },
+  });
+}
+
+// ============================================================================
+// Typed getter functions (used by internal consumers)
+// ============================================================================
+
+export async function getPollerSettings(): Promise<{
+  enabled: boolean;
+  intervalMs: number;
+}> {
+  const s = await getSettings(['pollerEnabled', 'pollerIntervalMs']);
+  return {
+    enabled: s.pollerEnabled,
+    intervalMs: s.pollerIntervalMs,
+  };
+}
+
+export async function getGeoIPSettings(): Promise<{ usePlexGeoip: boolean }> {
+  return { usePlexGeoip: await getSetting('usePlexGeoip') };
+}
+
+export async function getNetworkSettings(): Promise<{
+  externalUrl: string | null;
+  trustProxy: boolean;
+}> {
+  const s = await getSettings(['externalUrl', 'trustProxy']);
+  return {
+    externalUrl: s.externalUrl,
+    trustProxy: s.trustProxy,
+  };
+}
+
+export interface NotificationSettings {
+  discordWebhookUrl: string | null;
+  customWebhookUrl: string | null;
+  webhookFormat: WebhookFormat | null;
+  ntfyTopic: string | null;
+  ntfyAuthToken: string | null;
+  pushoverUserKey: string | null;
+  pushoverApiToken: string | null;
+  webhookSecret: string | null;
+  mobileEnabled: boolean;
+  unitSystem: UnitSystem;
+}
+
+export async function getNotificationSettings(): Promise<NotificationSettings> {
+  const s = await getSettings([
+    'discordWebhookUrl',
+    'customWebhookUrl',
+    'webhookFormat',
+    'ntfyTopic',
+    'ntfyAuthToken',
+    'pushoverUserKey',
+    'pushoverApiToken',
+    'mobileEnabled',
+    'unitSystem',
+  ]);
+  return {
+    ...s,
+    webhookSecret: null, // TODO: Phase 4
+  };
+}
+
+export async function getBackupScheduleSettings(): Promise<{
+  type: BackupScheduleType;
+  time: string;
+  dayOfWeek: number;
+  dayOfMonth: number;
+  retentionCount: number;
+}> {
+  const s = await getSettings([
+    'backupScheduleType',
+    'backupScheduleTime',
+    'backupScheduleDayOfWeek',
+    'backupScheduleDayOfMonth',
+    'backupRetentionCount',
+  ]);
+  return {
+    type: s.backupScheduleType,
+    time: s.backupScheduleTime,
+    dayOfWeek: s.backupScheduleDayOfWeek,
+    dayOfMonth: s.backupScheduleDayOfMonth,
+    retentionCount: s.backupRetentionCount,
+  };
+}

--- a/apps/server/src/services/tailscale.ts
+++ b/apps/server/src/services/tailscale.ts
@@ -19,15 +19,11 @@ import {
   type FSWatcher,
 } from 'node:fs';
 import { promisify } from 'node:util';
-import { db } from '../db/client.js';
-import { settings } from '../db/schema.js';
-import { eq } from 'drizzle-orm';
 import { registerService, unregisterService } from './serviceTracker.js';
+import { getSettings, setSettings, setSetting } from './settings.js';
 import type { TailscaleStatus, TailscaleInfo, TailscaleExitNode } from '@tracearr/shared';
 
 const execFileAsync = promisify(execFile);
-
-const SETTINGS_ID = 1;
 const TAILSCALED_BIN = '/usr/sbin/tailscaled';
 const TAILSCALE_BIN = '/usr/bin/tailscale';
 const STATE_FILE = '/tmp/ts-state';
@@ -137,22 +133,14 @@ class TailscaleService {
     }
 
     try {
-      const [row] = await db
-        .select({
-          tailscaleEnabled: settings.tailscaleEnabled,
-          tailscaleState: settings.tailscaleState,
-          tailscaleHostname: settings.tailscaleHostname,
-        })
-        .from(settings)
-        .where(eq(settings.id, SETTINGS_ID))
-        .limit(1);
+      const s = await getSettings(['tailscaleEnabled', 'tailscaleState', 'tailscaleHostname']);
 
-      if (!row?.tailscaleEnabled) {
+      if (!s.tailscaleEnabled) {
         console.log('[Tailscale] Initialized (disabled)');
         return;
       }
 
-      this.hostname = row.tailscaleHostname ?? null;
+      this.hostname = s.tailscaleHostname;
 
       await this.startDaemon();
       console.log('[Tailscale] Initialized (enabled, starting daemon)');
@@ -179,14 +167,10 @@ class TailscaleService {
     this.restartAttempts = 0;
 
     // Persist enabled state to DB
-    await db
-      .update(settings)
-      .set({
-        tailscaleEnabled: true,
-        tailscaleHostname: this.hostname,
-        updatedAt: new Date(),
-      })
-      .where(eq(settings.id, SETTINGS_ID));
+    await setSettings({
+      tailscaleEnabled: true,
+      tailscaleHostname: this.hostname,
+    });
 
     await this.startDaemon();
     return this.getInfo();
@@ -205,13 +189,7 @@ class TailscaleService {
     await this.killAll();
 
     // Mark as disabled in DB but preserve state + hostname for re-enable
-    await db
-      .update(settings)
-      .set({
-        tailscaleEnabled: false,
-        updatedAt: new Date(),
-      })
-      .where(eq(settings.id, SETTINGS_ID));
+    await setSetting('tailscaleEnabled', false);
 
     this.status = 'disabled';
     this.authUrl = null;
@@ -254,16 +232,12 @@ class TailscaleService {
       // Ignore
     }
 
-    // Clear all tailscale columns in DB
-    await db
-      .update(settings)
-      .set({
-        tailscaleEnabled: false,
-        tailscaleState: null,
-        tailscaleHostname: null,
-        updatedAt: new Date(),
-      })
-      .where(eq(settings.id, SETTINGS_ID));
+    // Clear all tailscale settings in DB
+    await setSettings({
+      tailscaleEnabled: false,
+      tailscaleState: null,
+      tailscaleHostname: null,
+    });
 
     this.status = 'disabled';
     this.authUrl = null;
@@ -304,14 +278,11 @@ class TailscaleService {
     let hasExistingState = existsSync(STATE_FILE);
     if (!hasExistingState) {
       try {
-        const [row] = await db
-          .select({ tailscaleState: settings.tailscaleState })
-          .from(settings)
-          .where(eq(settings.id, SETTINGS_ID))
-          .limit(1);
+        const s = await getSettings(['tailscaleState']);
+        const tailscaleState = s.tailscaleState;
 
-        if (row?.tailscaleState) {
-          writeFileSync(STATE_FILE, Buffer.from(row.tailscaleState, 'base64'));
+        if (tailscaleState) {
+          writeFileSync(STATE_FILE, Buffer.from(tailscaleState, 'base64'));
           hasExistingState = true;
           console.log('[Tailscale] Restored state from database');
         }
@@ -713,13 +684,7 @@ class TailscaleService {
       const stateData = readFileSync(STATE_FILE);
       const base64State = stateData.toString('base64');
 
-      await db
-        .update(settings)
-        .set({
-          tailscaleState: base64State,
-          updatedAt: new Date(),
-        })
-        .where(eq(settings.id, SETTINGS_ID));
+      await setSetting('tailscaleState', base64State);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error('[Tailscale] Failed to persist state:', msg);

--- a/apps/server/src/services/tautulli.ts
+++ b/apps/server/src/services/tautulli.ts
@@ -6,7 +6,8 @@ import { eq, and, isNull, isNotNull, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import type { TautulliImportProgress, TautulliImportResult } from '@tracearr/shared';
 import { db } from '../db/client.js';
-import { settings, sessions, serverUsers, users } from '../db/schema.js';
+import { sessions, serverUsers, users } from '../db/schema.js';
+import { getSettings } from './settings.js';
 import { refreshAggregates, checkAggregateNeedsRebuild } from '../db/timescale.js';
 import { enqueueMaintenanceJob } from '../jobs/maintenanceQueue.js';
 import { geoipService } from './geoip.js';
@@ -519,10 +520,9 @@ export class TautulliService {
     const skipRefresh = options?.skipRefresh ?? false;
 
     // Get Tautulli settings
-    const settingsRow = await db.select().from(settings).where(eq(settings.id, 1)).limit(1);
+    const config = await getSettings(['tautulliUrl', 'tautulliApiKey']);
 
-    const config = settingsRow[0];
-    if (!config?.tautulliUrl || !config?.tautulliApiKey) {
+    if (!config.tautulliUrl || !config.tautulliApiKey) {
       return {
         success: false,
         imported: 0,
@@ -1268,13 +1268,12 @@ export class TautulliService {
     const CONCURRENCY = 10; // 10 parallel API calls
 
     // Get Tautulli settings
-    const settingsRow = await db.select().from(settings).where(eq(settings.id, 1)).limit(1);
-    const config = settingsRow[0];
-    if (!config?.tautulliUrl || !config?.tautulliApiKey) {
+    const tautulliConfig = await getSettings(['tautulliUrl', 'tautulliApiKey']);
+    if (!tautulliConfig.tautulliUrl || !tautulliConfig.tautulliApiKey) {
       throw new Error('Tautulli is not configured');
     }
 
-    const tautulli = new TautulliService(config.tautulliUrl, config.tautulliApiKey);
+    const tautulli = new TautulliService(tautulliConfig.tautulliUrl, tautulliConfig.tautulliApiKey);
 
     // Test connection
     const connected = await tautulli.testConnection();

--- a/apps/server/test/integration/mobile.integration.test.ts
+++ b/apps/server/test/integration/mobile.integration.test.ts
@@ -17,15 +17,9 @@ import { eq } from 'drizzle-orm';
 import type { Redis } from 'ioredis';
 import type { AuthUser } from '@tracearr/shared';
 import { db } from '../../src/db/client.js';
-import {
-  users,
-  servers,
-  serverUsers,
-  settings,
-  mobileTokens,
-  mobileSessions,
-} from '../../src/db/schema.js';
+import { users, servers, serverUsers, mobileTokens, mobileSessions } from '../../src/db/schema.js';
 import { mobileRoutes } from '../../src/routes/mobile.js';
+import { setSetting, getSetting } from '../../src/services/settings.js';
 
 // Constants (matching mobile.ts)
 const TOKEN_EXPIRY_MINUTES = 15;
@@ -184,14 +178,8 @@ async function seedTestData(): Promise<TestData> {
     })
     .returning();
 
-  // Ensure settings row exists with mobile enabled
-  await db
-    .insert(settings)
-    .values({ id: 1, mobileEnabled: true })
-    .onConflictDoUpdate({
-      target: settings.id,
-      set: { mobileEnabled: true },
-    });
+  // Ensure mobile is enabled in settings
+  await setSetting('mobileEnabled', true);
 
   return {
     ownerId: user.id,
@@ -303,7 +291,7 @@ describe('Mobile Authentication Integration Tests', () => {
 
     it('should reject when mobile is disabled', async () => {
       // Disable mobile
-      await db.update(settings).set({ mobileEnabled: false }).where(eq(settings.id, 1));
+      await setSetting('mobileEnabled', false);
 
       const ownerToken = generateOwnerToken(app, testData);
 
@@ -487,7 +475,7 @@ describe('Mobile Authentication Integration Tests', () => {
     it('should allow pairing even when mobile is disabled (token was pre-generated)', async () => {
       // Note: /pair doesn't check mobileEnabled - tokens can be used if they were
       // generated before mobile was disabled. Disabling mobile only prevents NEW tokens.
-      await db.update(settings).set({ mobileEnabled: false }).where(eq(settings.id, 1));
+      await setSetting('mobileEnabled', false);
 
       const res = await app.inject({
         method: 'POST',
@@ -633,7 +621,7 @@ describe('Mobile Authentication Integration Tests', () => {
     it('should allow refresh even when mobile is disabled', async () => {
       // Note: /refresh doesn't check mobileEnabled - existing sessions continue working.
       // Disabling mobile only prevents NEW tokens and revokes sessions when explicitly disabled.
-      await db.update(settings).set({ mobileEnabled: false }).where(eq(settings.id, 1));
+      await setSetting('mobileEnabled', false);
 
       const res = await app.inject({
         method: 'POST',
@@ -885,7 +873,7 @@ describe('Mobile Authentication Integration Tests', () => {
   describe('POST /api/v1/mobile/enable - Enable Mobile Access', () => {
     beforeEach(async () => {
       // Ensure mobile is disabled
-      await db.update(settings).set({ mobileEnabled: false }).where(eq(settings.id, 1));
+      await setSetting('mobileEnabled', false);
     });
 
     it('should enable mobile access as owner', async () => {
@@ -901,8 +889,8 @@ describe('Mobile Authentication Integration Tests', () => {
       expect(res.json().isEnabled).toBe(true);
 
       // Verify in database
-      const [settingsRow] = await db.select().from(settings).where(eq(settings.id, 1));
-      expect(settingsRow.mobileEnabled).toBe(true);
+      const mobileEnabled = await getSetting('mobileEnabled');
+      expect(mobileEnabled).toBe(true);
     });
 
     it('should reject non-owner users', async () => {
@@ -951,8 +939,8 @@ describe('Mobile Authentication Integration Tests', () => {
       expect(res.json().success).toBe(true);
 
       // Verify mobile is disabled
-      const [settingsRow] = await db.select().from(settings).where(eq(settings.id, 1));
-      expect(settingsRow.mobileEnabled).toBe(false);
+      const mobileEnabled = await getSetting('mobileEnabled');
+      expect(mobileEnabled).toBe(false);
 
       // Verify all sessions were revoked
       const sessions = await db.select().from(mobileSessions);

--- a/apps/web/src/components/settings/ImportSettings.tsx
+++ b/apps/web/src/components/settings/ImportSettings.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -97,9 +98,8 @@ function TautulliImportSection({
 
           <div className="space-y-2">
             <Label htmlFor="tautulliApiKey">API Key</Label>
-            <Input
+            <PasswordInput
               id="tautulliApiKey"
-              type="password"
               placeholder="Your Tautulli API key"
               value={tautulliApiKey}
               onChange={(e) => setTautulliApiKey(e.target.value)}

--- a/apps/web/src/components/settings/notification-agents/AddAgentDialog.tsx
+++ b/apps/web/src/components/settings/notification-agents/AddAgentDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Field, FieldLabel, FieldError } from '@/components/ui/field';
 import { useUpdateSettings } from '@/hooks/queries/useSettings';
 import { toast } from 'sonner';
@@ -333,15 +334,25 @@ export function AddAgentDialog({
                         {field.label}
                         {field.required && <span className="text-destructive ml-1">*</span>}
                       </FieldLabel>
-                      <Input
-                        id={field.key}
-                        type={field.type === 'secret' ? 'password' : 'text'}
-                        placeholder={field.placeholder}
-                        value={formData[field.key] ?? ''}
-                        onChange={(e) => handleFieldChange(field.key, e.target.value)}
-                        onBlur={() => handleFieldBlur(field.key)}
-                        aria-invalid={!!error}
-                      />
+                      {field.type === 'secret' ? (
+                        <PasswordInput
+                          id={field.key}
+                          placeholder={field.placeholder}
+                          value={formData[field.key] ?? ''}
+                          onChange={(e) => handleFieldChange(field.key, e.target.value)}
+                          onBlur={() => handleFieldBlur(field.key)}
+                          aria-invalid={!!error}
+                        />
+                      ) : (
+                        <Input
+                          id={field.key}
+                          placeholder={field.placeholder}
+                          value={formData[field.key] ?? ''}
+                          onChange={(e) => handleFieldChange(field.key, e.target.value)}
+                          onBlur={() => handleFieldBlur(field.key)}
+                          aria-invalid={!!error}
+                        />
+                      )}
                       {error && <FieldError>{error}</FieldError>}
                     </Field>
                   );

--- a/apps/web/src/components/settings/notification-agents/EditAgentDialog.tsx
+++ b/apps/web/src/components/settings/notification-agents/EditAgentDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Field, FieldLabel, FieldError } from '@/components/ui/field';
 import { useUpdateSettings } from '@/hooks/queries/useSettings';
 import { toast } from 'sonner';
@@ -163,15 +164,25 @@ export function EditAgentDialog({ open, onOpenChange, agentType, settings }: Edi
                     {field.label}
                     {field.required && <span className="text-destructive ml-1">*</span>}
                   </FieldLabel>
-                  <Input
-                    id={field.key}
-                    type={field.type === 'secret' ? 'password' : 'text'}
-                    placeholder={field.placeholder}
-                    value={formData[field.key] ?? ''}
-                    onChange={(e) => handleFieldChange(field.key, e.target.value)}
-                    onBlur={() => handleFieldBlur(field.key)}
-                    aria-invalid={!!error}
-                  />
+                  {field.type === 'secret' ? (
+                    <PasswordInput
+                      id={field.key}
+                      placeholder={field.placeholder}
+                      value={formData[field.key] ?? ''}
+                      onChange={(e) => handleFieldChange(field.key, e.target.value)}
+                      onBlur={() => handleFieldBlur(field.key)}
+                      aria-invalid={!!error}
+                    />
+                  ) : (
+                    <Input
+                      id={field.key}
+                      placeholder={field.placeholder}
+                      value={formData[field.key] ?? ''}
+                      onChange={(e) => handleFieldChange(field.key, e.target.value)}
+                      onBlur={() => handleFieldBlur(field.key)}
+                      aria-invalid={!!error}
+                    />
+                  )}
                   {error && <FieldError>{error}</FieldError>}
                 </Field>
               );

--- a/apps/web/src/components/ui/autosave-field.tsx
+++ b/apps/web/src/components/ui/autosave-field.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
 import { Loader2, Check, AlertCircle, RotateCcw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Field, FieldLabel, FieldDescription, FieldError } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { NumericInput } from '@/components/ui/numeric-input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
@@ -178,7 +178,6 @@ interface AutosaveSecretFieldProps extends AutosaveFieldBaseProps {
   onChange: (value: string) => void;
   placeholder?: string;
   disabled?: boolean;
-  isMasked?: boolean; // Shows ******** for existing values
 }
 
 export function AutosaveSecretField({
@@ -193,38 +192,18 @@ export function AutosaveSecretField({
   onRetry,
   onReset,
   disabled,
-  isMasked,
   className,
 }: AutosaveSecretFieldProps) {
   const hasError = status === 'error';
-  const [isEditing, setIsEditing] = React.useState(false);
-
-  const displayValue = isMasked && !isEditing ? '' : value;
-  const displayPlaceholder = isMasked && !isEditing ? '••••••••' : placeholder;
-
-  const handleFocus = () => {
-    if (isMasked) {
-      setIsEditing(true);
-    }
-  };
-
-  const handleBlur = () => {
-    if (isMasked && !value) {
-      setIsEditing(false);
-    }
-  };
 
   return (
     <Field data-invalid={hasError} className={className}>
       <FieldHeader id={id} label={label} status={status} />
-      <Input
+      <PasswordInput
         id={id}
-        type="password"
-        value={displayValue}
+        value={value}
         onChange={(e) => onChange(e.target.value)}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        placeholder={displayPlaceholder}
+        placeholder={placeholder}
         disabled={disabled}
         aria-invalid={hasError}
       />

--- a/apps/web/src/components/ui/password-input.tsx
+++ b/apps/web/src/components/ui/password-input.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Input, type InputProps } from './input';
+
+const PasswordInput = React.forwardRef<HTMLInputElement, Omit<InputProps, 'type'>>(
+  ({ className, ...props }, ref) => {
+    const [visible, setVisible] = React.useState(false);
+
+    return (
+      <div className="relative">
+        <Input
+          type={visible ? 'text' : 'password'}
+          className={cn('pr-10', className)}
+          ref={ref}
+          {...props}
+        />
+        <button
+          type="button"
+          tabIndex={-1}
+          className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer"
+          onClick={() => setVisible((v) => !v)}
+          aria-label={visible ? 'Hide password' : 'Show password'}
+        >
+          {visible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+        </button>
+      </div>
+    );
+  }
+);
+PasswordInput.displayName = 'PasswordInput';
+
+export { PasswordInput };

--- a/packages/test-utils/src/db/reset.ts
+++ b/packages/test-utils/src/db/reset.ts
@@ -21,7 +21,7 @@ import { executeRawSql, closeTestPool } from './pool.js';
  * 8. server_users (depends on users, servers)
  * 9. servers (standalone)
  * 10. users (standalone)
- * 11. settings (standalone, single row)
+ * 11. settings (standalone, key-value store)
  */
 const TABLES_TO_TRUNCATE = [
   'violations',
@@ -34,7 +34,7 @@ const TABLES_TO_TRUNCATE = [
   'server_users',
   'servers',
   'users',
-  // Settings is a single-row config table, reset to defaults instead
+  'settings',
 ];
 
 /**
@@ -49,12 +49,6 @@ export async function resetTestDb(): Promise<void> {
   try {
     // Use a single TRUNCATE command with CASCADE for efficiency
     await executeRawSql(`TRUNCATE TABLE ${TABLES_TO_TRUNCATE.join(', ')} RESTART IDENTITY CASCADE`);
-
-    // Reset settings to defaults (it's a single-row table)
-    await executeRawSql(`
-      DELETE FROM settings WHERE id = 1;
-      INSERT INTO settings (id) VALUES (1);
-    `);
   } catch (error) {
     // Table might not exist yet if migrations haven't run
     if (error instanceof Error && error.message.includes('does not exist')) {

--- a/packages/test-utils/src/db/seed.ts
+++ b/packages/test-utils/src/db/seed.ts
@@ -23,7 +23,6 @@ export interface SeedResult {
  * - 1 owner user
  * - 1 Plex server
  * - 1 server_user linking them
- * - Default settings row
  */
 export async function seedBasicOwner(): Promise<SeedResult> {
   // Create owner user
@@ -49,12 +48,6 @@ export async function seedBasicOwner(): Promise<SeedResult> {
     RETURNING id
   `);
   const serverUserId = serverUserResult.rows[0].id as string;
-
-  // Ensure settings row exists
-  await executeRawSql(`
-    INSERT INTO settings (id) VALUES (1)
-    ON CONFLICT (id) DO NOTHING
-  `);
 
   return { userId, serverId, serverUserId };
 }
@@ -181,7 +174,8 @@ export async function seedMobilePairing(): Promise<SeedResult & { tokenHash: str
 
   // Enable mobile in settings
   await executeRawSql(`
-    UPDATE settings SET mobile_enabled = true WHERE id = 1
+    INSERT INTO settings (name, value) VALUES ('mobileEnabled', 'true'::jsonb)
+    ON CONFLICT (name) DO UPDATE SET value = 'true'::jsonb
   `);
 
   // Create a pairing token (hash of 'test-mobile-token')


### PR DESCRIPTION
## Summary

**Note:** This PR is based on and requires the `backup_restore` work in PR #534

Converts the settings table from a wide singleton row (~30 columns) to a key-value store (`name varchar(255) UNIQUE, value jsonb`). This makes adding new settings a one-line default instead of a migration + column + type change.

Also fixes a longstanding bug where secret fields (Tautulli API key, ntfy auth token, Pushover API token) were masked with `********` on the backend before being sent to the frontend. The masked value was displayed in editable input fields, and saving would write `********` back to the database, silently overwriting the real secret. Since the settings endpoints are owner-only and this is a self-hosted app, secrets are now returned as-is and the frontend handles visibility with password inputs and eye toggles.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Breaking change

## Related Issue

None

## Changes

**Settings KV migration:**
- New migration (`0056_large_iron_monger.sql`) creates `settings_new` KV table, copies data from the old singleton row, drops old table, renames new one
- New `apps/server/src/services/settings.ts` service with typed `getSetting<K>()`, `getSettings()`, `setSettings()`, and grouped getters (`getPollerSettings`, `getNotificationSettings`, etc.)
- All route handlers and services (`tailscale.ts`, `tautulli.ts`, `backupQueue.ts`, `setup.ts`, `debug.ts`, `mobile.ts`) now use the settings service instead of raw DB queries
- Settings route rewritten to use the service layer - GET returns `getAllSettings()`, PATCH validates with Zod then calls `setSettings()`
- Schema simplified to just `id`, `name`, `value` columns
- Test-utils seed/reset updated for KV format
- All settings tests rewritten against the new service mocks

**Secret masking fix:**
- Removed backend masking (`MASKED_KEYS`, `********` substitution) from `getAllSettings()`
- Removed `********` write-back guard from PATCH handler
- New `PasswordInput` component with eye toggle for secret visibility
- Updated `AddAgentDialog`, `EditAgentDialog`, `ImportSettings`, and `AutosaveSecretField` to use `PasswordInput` for secret fields
- Updated tests to verify real values are returned to owners

## Testing

- [x] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Settings route tests rewritten to mock the new settings service. Masking tests replaced with tests verifying real values are returned to owners.

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
