### PR TITLE
Sort User column by display name w/ username fallback

### DIFF
--- a/apps/web/src/pages/Users.tsx
+++ b/apps/web/src/pages/Users.tsx
@@ -46,6 +46,7 @@ export function Users() {
           return display || row.username;
         },
         sortingFn: 'alphanumeric',
+
         cell: ({ row }) => {
           const user = row.original;
           const avatarUrl = getAvatarUrl(user.serverId, user.thumbUrl, 40);
@@ -76,6 +77,19 @@ export function Users() {
             </div>
           );
         },
+      },
+      {
+        id: 'searchableName',
+        accessorFn: (row) => {
+          const identity = row.identityName?.trim() ?? '';
+          return `${identity} ${row.username}`.toLowerCase();
+        },
+        filterFn: 'includesString',
+        enableSorting: false, // don't show in UI
+        enableHiding: true,
+        enableColumnFilter: true,
+        header: () => null,
+        cell: () => null
       },
       {
         accessorKey: 'trustScore',
@@ -198,7 +212,7 @@ export function Users() {
               pageCount={totalPages}
               page={page}
               onPageChange={setPage}
-              filterColumn="username"
+              filterColumn="searchableName"
               filterValue={searchFilter}
               onRowClick={(user) => {
                 void navigate(`/users/${user.id}`);


### PR DESCRIPTION
## Summary

Adds logic to consider users friendly names when sorting the user list alphabetically. Fallback on username for alphabetic sorting if no friendly name is set.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

Closes #566 

## Changes

<!-- What specifically changed? -->

-Removed `accessorKey: 'username'`
-Added `id: 'displayName'`
-Added `accessorFn` to sort by `identityName?.trim() || username`


## Testing

- [x] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Verified sorting works by friendly name, verified username fallback sorting works as intended when friendly name is not set.

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
