### PR TITLE
Enhance debug page with more stats and log download button

### DIFF
--- a/apps/server/src/routes/__tests__/debug.test.ts
+++ b/apps/server/src/routes/__tests__/debug.test.ts
@@ -18,6 +18,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import sensible from '@fastify/sensible';
 import { randomUUID } from 'node:crypto';
 import type { AuthUser } from '@tracearr/shared';
+import type { Redis } from 'ioredis';
 
 // Mock the database module
 vi.mock('../../db/client.js', () => ({
@@ -46,6 +47,12 @@ async function buildTestApp(authUser: AuthUser): Promise<FastifyInstance> {
   app.decorate('authenticate', async (request: unknown) => {
     (request as { user: AuthUser }).user = authUser;
   });
+
+  // Mock redis (cast to satisfy ioredis type)
+  app.decorate('redis', {
+    info: async () => 'redis_version:7.0.0\r\nused_memory:1000000\r\n',
+    status: 'ready',
+  } as unknown as Redis);
 
   // Register routes
   await app.register(debugRoutes, { prefix: '/debug' });
@@ -142,6 +149,8 @@ describe('Debug Routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default execute mock — /debug/env calls db.execute(...).then() so it needs a promise
+    vi.mocked(db.execute).mockResolvedValue({ rows: [] } as never);
   });
 
   afterEach(async () => {
@@ -580,23 +589,16 @@ describe('Debug Routes', () => {
       expect(body).toHaveProperty('memoryUsage');
       expect(body).toHaveProperty('env');
 
-      // Check memory usage format
-      expect(body.memoryUsage.heapUsed).toMatch(/^\d+ MB$/);
-      expect(body.memoryUsage.heapTotal).toMatch(/^\d+ MB$/);
-      expect(body.memoryUsage.rss).toMatch(/^\d+ MB$/);
-
-      // Check env does not expose secrets
-      expect(body.env.DATABASE_URL).toMatch(/^\[(set|not set)\]$/);
-      expect(body.env.REDIS_URL).toMatch(/^\[(set|not set)\]$/);
-      expect(body.env.ENCRYPTION_KEY).toMatch(/^\[(set|not set)\]$/);
+      // Check memory usage format (formatBytes output e.g. "123.4 MB")
+      expect(body.memoryUsage.heapUsed).toMatch(/^[\d.]+ \w+$/);
+      expect(body.memoryUsage.rss).toMatch(/^[\d.]+ \w+$/);
     });
 
     it('masks sensitive environment variables', async () => {
       app = await buildTestApp(ownerUser);
 
-      // Set env vars temporarily
-      process.env.DATABASE_URL = 'postgres://secret:password@localhost/db';
-      process.env.REDIS_URL = 'redis://secret@localhost:6379';
+      // Set env var temporarily
+      process.env.CLAIM_CODE = 'secret-code';
 
       const response = await app.inject({
         method: 'GET',
@@ -606,25 +608,21 @@ describe('Debug Routes', () => {
       expect(response.statusCode).toBe(200);
       const body = response.json();
 
-      // Should show [set] not the actual values
-      expect(body.env.DATABASE_URL).toBe('[set]');
-      expect(body.env.REDIS_URL).toBe('[set]');
+      // Should show [set] not the actual value
+      expect(body.env.CLAIM_CODE).toBe('[set]');
 
       // Clean up
-      delete process.env.DATABASE_URL;
-      delete process.env.REDIS_URL;
+      delete process.env.CLAIM_CODE;
     });
 
-    it('shows [not set] for unset environment variables', async () => {
+    it('returns empty string for unset optional environment variables', async () => {
       app = await buildTestApp(ownerUser);
 
       // Ensure env vars are NOT set
-      const origDbUrl = process.env.DATABASE_URL;
-      const origRedisUrl = process.env.REDIS_URL;
-      const origEncKey = process.env.ENCRYPTION_KEY;
-      delete process.env.DATABASE_URL;
-      delete process.env.REDIS_URL;
-      delete process.env.ENCRYPTION_KEY;
+      const origClaimCode = process.env.CLAIM_CODE;
+      const origBasePath = process.env.BASE_PATH;
+      delete process.env.CLAIM_CODE;
+      delete process.env.BASE_PATH;
 
       const response = await app.inject({
         method: 'GET',
@@ -634,15 +632,13 @@ describe('Debug Routes', () => {
       expect(response.statusCode).toBe(200);
       const body = response.json();
 
-      // Should show [not set] for unset env vars
-      expect(body.env.DATABASE_URL).toBe('[not set]');
-      expect(body.env.REDIS_URL).toBe('[not set]');
-      expect(body.env.ENCRYPTION_KEY).toBe('[not set]');
+      // Should return empty string for unset optional vars
+      expect(body.env.CLAIM_CODE).toBe('');
+      expect(body.env.BASE_PATH).toBe('');
 
       // Restore original values
-      if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
-      if (origRedisUrl) process.env.REDIS_URL = origRedisUrl;
-      if (origEncKey) process.env.ENCRYPTION_KEY = origEncKey;
+      if (origClaimCode) process.env.CLAIM_CODE = origClaimCode;
+      if (origBasePath) process.env.BASE_PATH = origBasePath;
     });
   });
 });

--- a/apps/server/src/routes/debug.ts
+++ b/apps/server/src/routes/debug.ts
@@ -6,8 +6,10 @@
  */
 
 import type { FastifyPluginAsync } from 'fastify';
-import { promises as fs } from 'node:fs';
+import { promises as fs, createReadStream, createWriteStream } from 'node:fs';
+import os from 'node:os';
 import { join } from 'node:path';
+import archiver from 'archiver';
 import { sql } from 'drizzle-orm';
 import { db } from '../db/client.js';
 import { getActiveAggregateNames } from '../db/timescale.js';
@@ -47,6 +49,210 @@ import {
   libraryItems,
   librarySnapshots,
 } from '../db/schema.js';
+
+// Read a cgroup file, returning null if unavailable
+const readCgroup = async (path: string): Promise<string | null> => {
+  try {
+    const val = (await fs.readFile(path, 'utf8')).trim();
+    return val && val !== 'max' ? val : null;
+  } catch {
+    return null;
+  }
+};
+
+const formatBytes = (bytes: number) => {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+};
+
+const getContainerInfo = async () => {
+  const isDocker = await fs.access('/.dockerenv').then(
+    () => true,
+    () => false
+  );
+
+  const base = {
+    isDocker,
+    memoryLimit: formatBytes(os.totalmem()),
+    memoryUsage: formatBytes(os.totalmem() - os.freemem()),
+    cpuLimit: `${os.cpus().length} cores`,
+    cpuModel: os.cpus()[0]?.model ?? 'unknown',
+  };
+
+  if (!isDocker) return base;
+
+  // Try cgroup v2 first, then v1
+  const [memLimit, memUsage, cpuMax] = await Promise.all([
+    readCgroup('/sys/fs/cgroup/memory.max'),
+    readCgroup('/sys/fs/cgroup/memory.current'),
+    readCgroup('/sys/fs/cgroup/cpu.max'),
+  ]);
+
+  const [memLimitV1, memUsageV1, cpuQuota, cpuPeriod] = !memLimit
+    ? await Promise.all([
+        readCgroup('/sys/fs/cgroup/memory/memory.limit_in_bytes'),
+        readCgroup('/sys/fs/cgroup/memory/memory.usage_in_bytes'),
+        readCgroup('/sys/fs/cgroup/cpu/cpu.cfs_quota_us'),
+        readCgroup('/sys/fs/cgroup/cpu/cpu.cfs_period_us'),
+      ])
+    : [null, null, null, null];
+
+  // Override with cgroup values where available
+  const memLimitBytes = parseInt(memLimit ?? memLimitV1 ?? '', 10);
+  if (memLimitBytes > 0 && memLimitBytes < Number.MAX_SAFE_INTEGER) {
+    base.memoryLimit = formatBytes(memLimitBytes);
+  }
+
+  const memUsageBytes = parseInt(memUsage ?? memUsageV1 ?? '', 10);
+  if (memUsageBytes > 0) {
+    base.memoryUsage = formatBytes(memUsageBytes);
+  }
+
+  if (cpuMax) {
+    const parts = cpuMax.split(' ').map(Number);
+    const quota = parts[0] ?? 0;
+    const period = parts[1] ?? 0;
+    if (quota > 0 && period > 0) {
+      base.cpuLimit = `${(quota / period).toFixed(1)} cores`;
+    }
+  } else if (cpuQuota && cpuPeriod) {
+    const quota = parseInt(cpuQuota, 10);
+    const period = parseInt(cpuPeriod, 10);
+    if (quota > 0 && period > 0) {
+      base.cpuLimit = `${(quota / period).toFixed(1)} cores`;
+    }
+  }
+
+  return base;
+};
+
+interface ProcessInfo {
+  name: string;
+  memory: string;
+}
+
+/**
+ * Get a process list from /proc.
+ * Aggregates postgres workers into a single entry using RssAnon + RssShmem (once).
+ * Other processes use VmRSS directly.
+ */
+const getProcessList = async (): Promise<ProcessInfo[]> => {
+  try {
+    const entries = await fs.readdir('/proc');
+    let pgAnonTotal = 0;
+    let pgSharedMax = 0;
+    const others: ProcessInfo[] = [];
+
+    await Promise.all(
+      entries
+        .filter((e) => /^\d+$/.test(e))
+        .map(async (pid) => {
+          try {
+            const status = await fs.readFile(`/proc/${pid}/status`, 'utf8');
+            const rssMatch = status.match(/^VmRSS:\s+(\d+)\s+kB$/m);
+            if (!rssMatch?.[1]) return; // kernel thread
+
+            const nameMatch = status.match(/^Name:\s+(.+)$/m);
+            const name = nameMatch?.[1]?.trim() ?? 'unknown';
+
+            const anonMatch = status.match(/^RssAnon:\s+(\d+)\s+kB$/m);
+            const anon = parseInt(anonMatch?.[1] ?? '0', 10) * 1024;
+
+            if (name === 'postgres') {
+              pgAnonTotal += anon;
+              const shmMatch = status.match(/^RssShmem:\s+(\d+)\s+kB$/m);
+              const shm = parseInt(shmMatch?.[1] ?? '0', 10) * 1024;
+              if (shm > pgSharedMax) pgSharedMax = shm;
+            } else {
+              others.push({ name, memory: formatBytes(anon) });
+            }
+          } catch {
+            // Process may have exited
+          }
+        })
+    );
+
+    const result: ProcessInfo[] = [];
+    if (pgAnonTotal > 0 || pgSharedMax > 0) {
+      result.push({ name: 'postgres', memory: formatBytes(pgAnonTotal + pgSharedMax) });
+    }
+    result.push(...others);
+    return result.sort((a, b) => a.name.localeCompare(b.name));
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Parse a Docker volume source path into a friendly display name.
+ * e.g. "/var/lib/docker/volumes/compose_tracearr_redis/_data" →
+ *   last segment "_data" indicates a Docker volume, parent "compose_tracearr_redis"
+ *   starts with "compose_" so the volume name is "tracearr_redis".
+ * Falls back to the raw source path for bind mounts.
+ */
+const formatVolumeSource = (source: string): string => {
+  const parts = source.split('/').filter(Boolean);
+  const last = parts[parts.length - 1];
+  const parent = parts[parts.length - 2];
+
+  if (last === '_data' && parent) {
+    // Strip the Compose project prefix (everything up to the first underscore)
+    const underscoreIdx = parent.indexOf('_');
+    if (underscoreIdx !== -1) {
+      return parent.slice(underscoreIdx + 1);
+    }
+    return parent;
+  }
+
+  return source;
+};
+
+const getVolumeMounts = async (): Promise<{ path: string; source: string; free: string }[]> => {
+  try {
+    const raw = await fs.readFile('/proc/self/mountinfo', 'utf8');
+    const mounts = raw
+      .split('\n')
+      .filter(Boolean)
+      .filter((line) => {
+        // Field 4 = mount point — only keep mounts under /data
+        const mountPoint = line.split(' ')[4];
+        return mountPoint === '/data' || mountPoint?.startsWith('/data/');
+      })
+      .map((line) => {
+        const fields = line.split(' ');
+        // Field 3 = root (source path), Field 4 = mount point
+        return { source: fields[3] ?? '', path: fields[4] ?? '' };
+      });
+
+    // Dedupe by mount path
+    const seen = new Set<string>();
+    const unique = mounts.filter((m) => {
+      if (seen.has(m.path)) return false;
+      seen.add(m.path);
+      return true;
+    });
+
+    const results = await Promise.all(
+      unique.map(async ({ path, source }) => {
+        try {
+          const stat = await fs.statfs(path);
+          const free = stat.bsize * stat.bavail;
+
+          return { path, source: formatVolumeSource(source), free: formatBytes(free) };
+        } catch {
+          return null;
+        }
+      })
+    );
+
+    return results.filter((r): r is NonNullable<typeof r> => r !== null);
+  } catch {
+    return [];
+  }
+};
 
 // Gate log explorer feature to supervised deployments only
 const IS_SUPERVISED = (getCurrentTag() ?? '').toLowerCase().includes('supervised');
@@ -492,6 +698,67 @@ export const debugRoutes: FastifyPluginAsync = async (app) => {
   });
 
   /**
+   * GET /debug/logs/download - Download all logs as a zip
+   */
+  app.get('/logs/download', async (_request, reply) => {
+    if (!IS_SUPERVISED) {
+      return reply.notFound('Log explorer is only available in supervised mode');
+    }
+
+    // Find logs that exist
+    const existing = (
+      await Promise.all(
+        SUPERVISOR_LOG_FILES.map(async (name) => {
+          const filePath = join(SUPERVISOR_LOG_DIR, name);
+          try {
+            await fs.stat(filePath);
+            return { name, filePath };
+          } catch {
+            return null;
+          }
+        })
+      )
+    ).filter((f): f is { name: string; filePath: string } => f !== null);
+
+    if (existing.length === 0) {
+      return reply.notFound('No log files found');
+    }
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = `tracearr-logs-${timestamp}.zip`;
+    const zipPath = join(os.tmpdir(), filename);
+
+    try {
+      // Create zip
+      await new Promise<void>((resolve, reject) => {
+        const output = createWriteStream(zipPath);
+        const archive = archiver('zip', { zlib: { level: 1 } });
+        output.on('close', resolve);
+        archive.on('error', reject);
+        archive.pipe(output);
+        for (const { name, filePath } of existing) {
+          archive.append(createReadStream(filePath), { name });
+        }
+        void archive.finalize();
+      });
+
+      const stream = createReadStream(zipPath);
+      // Clean up zip after stream finishes
+      stream.on('close', () => {
+        void fs.unlink(zipPath);
+      });
+
+      return await reply
+        .header('Content-Type', 'application/zip')
+        .header('Content-Disposition', `attachment; filename="${filename}"`)
+        .send(stream);
+    } catch (err) {
+      void fs.unlink(zipPath);
+      throw err;
+    }
+  });
+
+  /**
    * GET /debug/logs/:name - Tail supervised log file
    */
   app.get('/logs/:name', async (request, reply) => {
@@ -518,22 +785,62 @@ export const debugRoutes: FastifyPluginAsync = async (app) => {
    * GET /debug/env - Safe environment info (no secrets)
    */
   app.get('/env', async () => {
+    // Query database versions in parallel
+    const [pgVersionResult, tsVersionResult, redisInfo, container] = await Promise.all([
+      db.execute(sql`SELECT version()`).then(
+        (r) => {
+          const full = (r.rows[0] as { version: string })?.version ?? '';
+          return full.match(/^PostgreSQL\s+([\d.]+)/)?.[1] ?? full;
+        },
+        () => 'unknown'
+      ),
+      db.execute(sql`SELECT extversion FROM pg_extension WHERE extname = 'timescaledb'`).then(
+        (r) => (r.rows[0] as { extversion: string })?.extversion ?? 'not installed',
+        () => 'not installed'
+      ),
+      app.redis.info().then(
+        (raw) => {
+          const get = (key: string) => raw.match(new RegExp(`${key}:(.+)`))?.[1]?.trim();
+          return { version: get('redis_version') ?? 'unknown' };
+        },
+        () => ({ version: 'unknown' })
+      ),
+      getContainerInfo(),
+    ]);
+
+    const loadAvg = os.loadavg();
+
     return {
       nodeVersion: process.version,
       platform: process.platform,
       arch: process.arch,
       uptime: Math.round(process.uptime()),
+      systemUptime: Math.round(os.uptime()),
+      loadAverage: [
+        (loadAvg[0] ?? 0).toFixed(2),
+        (loadAvg[1] ?? 0).toFixed(2),
+        (loadAvg[2] ?? 0).toFixed(2),
+      ],
       memoryUsage: {
-        heapUsed: `${Math.round(process.memoryUsage().heapUsed / 1024 / 1024)} MB`,
-        heapTotal: `${Math.round(process.memoryUsage().heapTotal / 1024 / 1024)} MB`,
-        rss: `${Math.round(process.memoryUsage().rss / 1024 / 1024)} MB`,
+        heapUsed: formatBytes(process.memoryUsage().heapUsed),
+        rss: formatBytes(process.memoryUsage().rss),
       },
+      database: {
+        postgresVersion: pgVersionResult,
+        timescaleVersion: tsVersionResult,
+      },
+      redis: { version: redisInfo.version },
+      container,
+      volumes: container.isDocker ? await getVolumeMounts() : [],
+      processes: container.isDocker ? await getProcessList() : [],
       env: {
         NODE_ENV: process.env.NODE_ENV ?? 'development',
-        DATABASE_URL: process.env.DATABASE_URL ? '[set]' : '[not set]',
-        REDIS_URL: process.env.REDIS_URL ? '[set]' : '[not set]',
-        ENCRYPTION_KEY: process.env.ENCRYPTION_KEY ? '[set]' : '[not set]',
-        GEOIP_DB_PATH: process.env.GEOIP_DB_PATH ?? '[not set]',
+        LOG_LEVEL: process.env.LOG_LEVEL ?? 'info',
+        TZ: process.env.TZ ?? 'UTC',
+        REDIS_PREFIX: process.env.REDIS_PREFIX ?? '',
+        CLAIM_CODE: process.env.CLAIM_CODE ? '[set]' : '',
+        BASE_PATH: process.env.BASE_PATH ?? '',
+        DNS_CACHE_MAX_TTL: process.env.DNS_CACHE_MAX_TTL ?? '',
         APP_VERSION: getCurrentVersion(),
         APP_TAG: getCurrentTag() ?? '[not set]',
         APP_COMMIT: getCurrentCommit() ?? '[not set]',

--- a/apps/web/src/lib/debugFetch.ts
+++ b/apps/web/src/lib/debugFetch.ts
@@ -24,3 +24,15 @@ export async function debugFetch<T>(path: string, options: RequestInit = {}): Pr
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json() as Promise<T>;
 }
+
+/**
+ * Raw fetch for debug endpoints (e.g. file downloads)
+ */
+export async function debugRawFetch(path: string): Promise<Response> {
+  const token = tokenStorage.getAccessToken();
+  const res = await fetch(`${BASE_PATH}${API_BASE_PATH}/debug${path}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res;
+}

--- a/apps/web/src/pages/Debug.tsx
+++ b/apps/web/src/pages/Debug.tsx
@@ -18,6 +18,7 @@ import {
   Link2,
   Camera,
   Loader2,
+  Download,
 } from 'lucide-react';
 import type { ColumnDef } from '@tanstack/react-table';
 import { Button } from '@/components/ui/button';
@@ -37,7 +38,7 @@ import {
 } from '@/components/ui/dialog';
 import { useVersion } from '@/hooks/queries';
 import { tokenStorage, api, BASE_URL } from '@/lib/api';
-import { debugFetch } from '@/lib/debugFetch';
+import { debugFetch, debugRawFetch } from '@/lib/debugFetch';
 import { TasksTab } from '@/components/debug/TasksTab';
 import { toast } from 'sonner';
 import { format, formatDistanceToNow } from 'date-fns';
@@ -66,11 +67,28 @@ interface EnvInfo {
   platform: string;
   arch: string;
   uptime: number;
+  systemUptime: number;
+  loadAverage: [string, string, string];
   memoryUsage: {
     heapUsed: string;
-    heapTotal: string;
     rss: string;
   };
+  database: {
+    postgresVersion: string;
+    timescaleVersion: string;
+  };
+  redis: {
+    version: string;
+  };
+  container: {
+    isDocker: boolean;
+    memoryLimit: string;
+    memoryUsage: string;
+    cpuLimit: string;
+    cpuModel: string;
+  };
+  volumes: { path: string; source: string; free: string }[];
+  processes: { name: string; memory: string }[];
   env: Record<string, string>;
 }
 
@@ -194,6 +212,26 @@ export function Debug() {
   const handleLogsRefresh = () => {
     void logFiles.refetch();
     void logEntries.refetch();
+  };
+
+  const [isDownloadingLogs, setIsDownloadingLogs] = useState(false);
+  const handleDownloadLogs = async () => {
+    setIsDownloadingLogs(true);
+    try {
+      const res = await debugRawFetch('/logs/download');
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const disposition = res.headers.get('Content-Disposition');
+      a.download = disposition?.match(/filename="(.+)"/)?.[1] ?? 'tracearr-logs.zip';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      toast.error('Failed to download logs');
+    } finally {
+      setIsDownloadingLogs(false);
+    }
   };
 
   // Snapshot management state
@@ -500,6 +538,10 @@ export function Debug() {
                       <div className="font-mono">
                         {envInfo.data.platform}/{envInfo.data.arch}
                       </div>
+                      <div className="text-muted-foreground">Docker</div>
+                      <div className="font-mono">
+                        {envInfo.data.container.isDocker ? 'Yes' : 'No'}
+                      </div>
                       <div className="text-muted-foreground">Uptime</div>
                       <div className="font-mono">{formatUptime(envInfo.data.uptime)}</div>
                       <div className="text-muted-foreground">Heap Used</div>
@@ -507,18 +549,77 @@ export function Debug() {
                       <div className="text-muted-foreground">RSS</div>
                       <div className="font-mono">{envInfo.data.memoryUsage.rss}</div>
                     </div>
+
+                    <p className="mt-6 mb-3 text-sm font-medium">Infrastructure</p>
+                    <div className="grid grid-cols-2 gap-2 text-sm">
+                      <div className="text-muted-foreground">Redis Version</div>
+                      <div className="font-mono">{envInfo.data.redis.version}</div>
+                      <div className="text-muted-foreground">PostgreSQL Version</div>
+                      <div className="font-mono">{envInfo.data.database.postgresVersion}</div>
+                      <div className="text-muted-foreground">TimescaleDB Version</div>
+                      <div className="font-mono">{envInfo.data.database.timescaleVersion}</div>
+                    </div>
+
+                    {envInfo.data.volumes.length > 0 && (
+                      <>
+                        <p className="mt-6 mb-3 text-sm font-medium">Volume Mounts</p>
+                        <div className="grid grid-cols-2 gap-2 text-sm">
+                          {envInfo.data.volumes.map((vol) => (
+                            <div key={vol.path} className="contents">
+                              <div className="text-muted-foreground">
+                                {vol.source}:{vol.path}
+                              </div>
+                              <div className="font-mono">{vol.free} free</div>
+                            </div>
+                          ))}
+                        </div>
+                      </>
+                    )}
                   </div>
-                  {/* Environment Variables */}
+                  {/* Environment Variables & Processes */}
                   <div>
                     <p className="mb-3 text-sm font-medium">Environment Variables</p>
-                    <div className="grid grid-cols-2 gap-2 text-sm">
-                      {Object.entries(envInfo.data.env).map(([key, value]) => (
-                        <div key={key} className="contents">
-                          <div className="text-muted-foreground truncate">{key}</div>
-                          <div className="font-mono text-xs">{value}</div>
-                        </div>
-                      ))}
+                    <div className="grid grid-cols-[40%_60%] gap-2 text-sm">
+                      {Object.entries(envInfo.data.env)
+                        .filter(([, value]) => value !== '')
+                        .map(([key, value]) => (
+                          <div key={key} className="contents">
+                            <div className="text-muted-foreground truncate">{key}</div>
+                            <div className="font-mono text-xs">{value}</div>
+                          </div>
+                        ))}
                     </div>
+
+                    <p className="mt-6 mb-3 text-sm font-medium">System Stats</p>
+                    <div className="grid grid-cols-[40%_60%] gap-2 text-sm">
+                      <div className="text-muted-foreground">Memory Used / Total</div>
+                      <div className="font-mono">
+                        {envInfo.data.container.memoryUsage} / {envInfo.data.container.memoryLimit}
+                      </div>
+                      <div className="text-muted-foreground">CPU</div>
+                      <div className="font-mono">
+                        {envInfo.data.container.cpuLimit.replace(' cores', '')} x{' '}
+                        {envInfo.data.container.cpuModel}
+                      </div>
+                      <div className="text-muted-foreground">Load Average (1m / 5m / 15m)</div>
+                      <div className="font-mono">{envInfo.data.loadAverage.join(' / ')}</div>
+                      <div className="text-muted-foreground">System Uptime</div>
+                      <div className="font-mono">{formatUptime(envInfo.data.systemUptime)}</div>
+                    </div>
+
+                    {envInfo.data.processes.length > 0 && (
+                      <>
+                        <p className="mt-6 mb-3 text-sm font-medium">Process Memory Usage</p>
+                        <div className="grid grid-cols-[40%_60%] gap-2 text-sm">
+                          {envInfo.data.processes.map((proc, i) => (
+                            <div key={`${proc.name}-${i}`} className="contents">
+                              <div className="text-muted-foreground">{proc.name}</div>
+                              <div className="font-mono">{proc.memory}</div>
+                            </div>
+                          ))}
+                        </div>
+                      </>
+                    )}
                   </div>
                 </div>
               )}
@@ -922,6 +1023,14 @@ export function Debug() {
                       disabled={logEntries.isFetching || logLimit >= MAX_LOG_LIMIT}
                     >
                       Load More
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={handleDownloadLogs}
+                      disabled={isDownloadingLogs}
+                    >
+                      <Download className="mr-2 h-4 w-4" />
+                      {isDownloadingLogs ? 'Downloading...' : 'Download All'}
                     </Button>
                   </div>
 


### PR DESCRIPTION
## Summary

Expands the debug page's Overview tab with infrastructure, container, and system metrics, and adds a "Download All" button to the Logs tab that zips all supervisor log files for easy collection.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

N/A

## Changes

- Add infrastructure info to Overview: Redis version, PostgreSQL version, TimescaleDB version
- Add container detection via `/.dockerenv` and display Docker status in Runtime
- Add container metrics from cgroup v2/v1: memory usage/limit, CPU cores/model
- Add system stats section: load average (1m/5m/15m), system uptime
- Add process memory usage list (Docker only), aggregating postgres workers to avoid shared memory double-counting
- Add volume mount display (Docker only) for `/data` mounts with free space, parsing Docker volume names from mountinfo
- Add environment variables display (LOG_LEVEL, TZ, REDIS_PREFIX, CLAIM_CODE, BASE_PATH, DNS_CACHE_MAX_TTL), hiding unset optional vars from UI
- Remove pointless env vars (DATABASE_URL, REDIS_URL, ENCRYPTION_KEY, GEOIP_DB_PATH) that always showed "[set]"
- Use `formatBytes` for human-readable memory sizes throughout
- Add `GET /debug/logs/download` endpoint that zips all supervisor log files with timestamped filename
- Add `debugRawFetch` helper for non-JSON debug endpoint responses
- Add "Download All" button on the Logs tab
- Update debug tests to match new env var list and memory format

## Screenshots

Debug overview with expanded stats (in supervised image):
<img width="1627" height="689" alt="Screenshot from 2026-03-07 11-15-07" src="https://github.com/user-attachments/assets/d6cd35f2-2fba-47a9-a716-4ebe6548d686" />

Download all logs button:
<img width="527" height="362" alt="Screenshot from 2026-03-07 14-14-06" src="https://github.com/user-attachments/assets/f4ef66fc-c1b4-4263-9604-1695eded6aee" />



## Testing

- [ ] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Updated existing debug route tests to match the new env var list and memory format. Manually verified all new sections render correctly and the log download produces a valid zip.

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
