### PR TITLE
Silence Plex Pass gated statistics errors for non-subscribers

### DIFF
--- a/apps/server/src/routes/servers.ts
+++ b/apps/server/src/routes/servers.ts
@@ -495,29 +495,18 @@ export const serverRoutes: FastifyPluginAsync = async (app) => {
       return reply.badRequest('Server statistics are only available for Plex servers');
     }
 
-    try {
-      const client = new PlexClient({
-        url: server.url,
-        token: server.token,
-      });
+    const client = new PlexClient({
+      url: server.url,
+      token: server.token,
+    });
 
-      const data = await client.getServerStatistics(SERVER_STATS_CONFIG.TIMESPAN_SECONDS);
+    const data = await client.getServerStatistics(SERVER_STATS_CONFIG.TIMESPAN_SECONDS);
 
-      // DEBUG: Log what we got back
-      app.log.info(
-        { serverId: id, dataLength: data.length, firstItem: data[0] },
-        'Server statistics fetched'
-      );
-
-      return {
-        serverId: id,
-        data,
-        fetchedAt: new Date().toISOString(),
-      };
-    } catch (error) {
-      app.log.error({ error, serverId: id }, 'Failed to fetch server statistics');
-      return reply.internalServerError('Failed to fetch server statistics');
-    }
+    return {
+      serverId: id,
+      data,
+      fetchedAt: new Date().toISOString(),
+    };
   });
 
   /**
@@ -544,23 +533,18 @@ export const serverRoutes: FastifyPluginAsync = async (app) => {
       return reply.badRequest('Bandwidth statistics are only available for Plex servers');
     }
 
-    try {
-      const client = new PlexClient({
-        url: server.url,
-        token: server.token,
-      });
+    const client = new PlexClient({
+      url: server.url,
+      token: server.token,
+    });
 
-      const data = await client.getServerBandwidth(BANDWIDTH_STATS_CONFIG.TIMESPAN_SECONDS);
+    const data = await client.getServerBandwidth(BANDWIDTH_STATS_CONFIG.TIMESPAN_SECONDS);
 
-      return {
-        serverId: id,
-        data,
-        fetchedAt: new Date().toISOString(),
-      };
-    } catch (error) {
-      app.log.error({ error, serverId: id }, 'Failed to fetch bandwidth statistics');
-      return reply.internalServerError('Failed to fetch bandwidth statistics');
-    }
+    return {
+      serverId: id,
+      data,
+      fetchedAt: new Date().toISOString(),
+    };
   });
 
   /**

--- a/apps/server/src/services/mediaServer/plex/client.ts
+++ b/apps/server/src/services/mediaServer/plex/client.ts
@@ -416,13 +416,18 @@ export class PlexClient implements IMediaServerClient, IMediaServerClientWithHis
   async getServerStatistics(timespan: number = 6): Promise<PlexStatisticsDataPoint[]> {
     const url = `${this.baseUrl}/statistics/resources?timespan=${timespan}`;
 
-    const data = await fetchJson<unknown>(url, {
-      headers: this.buildHeaders(),
-      service: 'plex',
-      timeout: 10000,
-    });
+    try {
+      const data = await fetchJson<unknown>(url, {
+        headers: this.buildHeaders(),
+        service: 'plex',
+        timeout: 10000,
+      });
 
-    return parseStatisticsResourcesResponse(data);
+      return parseStatisticsResourcesResponse(data);
+    } catch {
+      // Requires Plex Pass — silently return empty when unavailable
+      return [];
+    }
   }
 
   /**
@@ -437,13 +442,18 @@ export class PlexClient implements IMediaServerClient, IMediaServerClientWithHis
   async getServerBandwidth(timespan: number = 6): Promise<PlexBandwidthDataPoint[]> {
     const url = `${this.baseUrl}/statistics/bandwidth?timespan=${timespan}`;
 
-    const data = await fetchJson<unknown>(url, {
-      headers: this.buildHeaders(),
-      service: 'plex',
-      timeout: 10000,
-    });
+    try {
+      const data = await fetchJson<unknown>(url, {
+        headers: this.buildHeaders(),
+        service: 'plex',
+        timeout: 10000,
+      });
 
-    return parseStatisticsBandwidthResponse(data);
+      return parseStatisticsBandwidthResponse(data);
+    } catch {
+      // Requires Plex Pass — silently return empty when unavailable
+      return [];
+    }
   }
 
   // ==========================================================================


### PR DESCRIPTION
## Summary

Plex's `/statistics/resources` and `/statistics/bandwidth` endpoints require Plex Pass. Users without it were getting 500 errors logged every 6-10 seconds (the frontend poll interval), spamming server logs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

N/A

## Changes

- `PlexClient.getServerStatistics()` and `getServerBandwidth()` now catch errors and return empty arrays instead of throwing, matching the existing pattern used by `getMediaMetadata()`
- Removed try/catch + error logging + 500 responses from the `/servers/:id/statistics` and `/servers/:id/bandwidth` routes since the client no longer throws
- Removed a leftover `DEBUG: Log what we got back` info log that was firing every 10 seconds in the statistics route

## Screenshots

N/A - no UI changes; frontend already handles empty data gracefully with a "No data available" placeholder.

## Testing

- [ ] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
