### PR TITLE
Fix #560 basic auth credentials in notification webhook URLs

### DIFF
--- a/apps/server/src/services/__tests__/notify.test.ts
+++ b/apps/server/src/services/__tests__/notify.test.ts
@@ -117,7 +117,7 @@ describe('NotificationManager', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://ntfy.example.com',
+        'https://ntfy.example.com/',
         expect.objectContaining({
           method: 'POST',
           headers: {
@@ -150,7 +150,7 @@ describe('NotificationManager', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://ntfy.example.com',
+        'https://ntfy.example.com/',
         expect.objectContaining({
           method: 'POST',
           headers: {
@@ -257,7 +257,7 @@ describe('NotificationManager', () => {
       await manager.notifyServerDown('Plex Server', settings);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://ntfy.example.com',
+        'https://ntfy.example.com/',
         expect.objectContaining({
           headers: {
             'Content-Type': 'application/json',
@@ -318,7 +318,7 @@ describe('NotificationManager', () => {
       await manager.notifyServerUp('Plex Server', settings);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://ntfy.example.com',
+        'https://ntfy.example.com/',
         expect.objectContaining({
           headers: {
             'Content-Type': 'application/json',
@@ -385,7 +385,7 @@ describe('NotificationManager', () => {
       await manager.notifySessionStarted(session, settings);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://ntfy.example.com',
+        'https://ntfy.example.com/',
         expect.objectContaining({
           headers: {
             'Content-Type': 'application/json',
@@ -498,7 +498,7 @@ describe('testAgent', () => {
 
     expect(result.success).toBe(true);
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://ntfy.example.com',
+      'https://ntfy.example.com/',
       expect.objectContaining({
         method: 'POST',
         headers: {
@@ -530,7 +530,7 @@ describe('testAgent', () => {
 
     expect(result.success).toBe(true);
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://ntfy.example.com',
+      'https://ntfy.example.com/',
       expect.objectContaining({
         method: 'POST',
         headers: {

--- a/apps/server/src/services/notifications/agents/apprise.ts
+++ b/apps/server/src/services/notifications/agents/apprise.ts
@@ -165,9 +165,10 @@ export class AppriseAgent extends BaseAgent {
   }
 
   private async sendWebhook(webhookUrl: string, payload: ApprisePayload): Promise<void> {
-    const response = await fetch(webhookUrl, {
+    const { url, authHeaders } = this.buildFetchOptions(webhookUrl);
+    const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders },
       body: JSON.stringify(payload),
     });
 

--- a/apps/server/src/services/notifications/agents/base.ts
+++ b/apps/server/src/services/notifications/agents/base.ts
@@ -121,4 +121,28 @@ export abstract class BaseAgent implements NotificationAgent {
   protected failureTestResult(error: string): TestResult {
     return { success: false, error };
   }
+
+  /**
+   * Build fetch-compatible URL and headers from a URL that may contain
+   * embedded basic-auth credentials. Credentials are extracted and sent
+   * as an Authorization header instead.
+   */
+  protected buildFetchOptions(rawUrl: string): {
+    url: string;
+    authHeaders: Record<string, string>;
+  } {
+    const parsed = new URL(rawUrl);
+    const authHeaders: Record<string, string> = {};
+
+    if (parsed.username || parsed.password) {
+      const credentials = btoa(
+        `${decodeURIComponent(parsed.username)}:${decodeURIComponent(parsed.password)}`
+      );
+      authHeaders['Authorization'] = `Basic ${credentials}`;
+      parsed.username = '';
+      parsed.password = '';
+    }
+
+    return { url: parsed.toString(), authHeaders };
+  }
 }

--- a/apps/server/src/services/notifications/agents/gotify.ts
+++ b/apps/server/src/services/notifications/agents/gotify.ts
@@ -161,9 +161,10 @@ export class GotifyAgent extends BaseAgent {
   }
 
   private async sendWebhook(webhookUrl: string, payload: GotifyPayload): Promise<void> {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const { url, authHeaders } = this.buildFetchOptions(webhookUrl);
+    const headers: Record<string, string> = { 'Content-Type': 'application/json', ...authHeaders };
 
-    const response = await fetch(webhookUrl, {
+    const response = await fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(payload),

--- a/apps/server/src/services/notifications/agents/json-webhook.ts
+++ b/apps/server/src/services/notifications/agents/json-webhook.ts
@@ -227,9 +227,10 @@ export class JsonWebhookAgent extends BaseAgent {
   }
 
   private async sendWebhook(webhookUrl: string, payload: JsonWebhookPayload): Promise<void> {
-    const response = await fetch(webhookUrl, {
+    const { url, authHeaders } = this.buildFetchOptions(webhookUrl);
+    const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders },
       body: JSON.stringify(payload),
     });
     const text = await response.text().catch(() => '');

--- a/apps/server/src/services/notifications/agents/ntfy.ts
+++ b/apps/server/src/services/notifications/agents/ntfy.ts
@@ -185,12 +185,13 @@ export class NtfyAgent extends BaseAgent {
     payload: NtfyPayload,
     authToken: string | null
   ): Promise<void> {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const { url, authHeaders } = this.buildFetchOptions(webhookUrl);
+    const headers: Record<string, string> = { 'Content-Type': 'application/json', ...authHeaders };
     if (authToken) {
       headers['Authorization'] = `Bearer ${authToken}`;
     }
 
-    const response = await fetch(webhookUrl, {
+    const response = await fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary

Fixes notification agents failing when webhook URLs contain basic auth credentials (e.g. `http://user:pass@apprise:8000`). The `fetch()` API rejects URLs with embedded credentials, so we now extract them and send as an `Authorization: Basic` header instead.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

Closes #560

## Changes

- Added `buildFetchOptions()` to `BaseAgent` that parses URLs, extracts any embedded basic auth credentials, and returns a clean URL with an `Authorization` header
- Applied to apprise, gotify, json-webhook, and ntfy agents
- Discord and pushover agents are unchanged - Discord doesn't support basic auth, pushover uses a hardcoded API URL

## Screenshots

N/A

## Testing

- [X] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [ ] Tested manually

Updated existing notification test URL assertions to account for URL normalization (trailing slash added by new `URL().toString()`)

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
