### PR TITLE
Fix 415 status issues with Jellyfin messages

### DIFF
--- a/apps/server/src/services/mediaServer/shared/baseMediaServerClient.ts
+++ b/apps/server/src/services/mediaServer/shared/baseMediaServerClient.ts
@@ -446,14 +446,13 @@ export abstract class BaseMediaServerClient
     header?: string,
     timeoutMs?: number
   ): Promise<boolean> {
-    const params = new URLSearchParams();
-    params.append('Text', text);
-    if (header) params.append('Header', header);
-    if (timeoutMs) params.append('TimeoutMs', String(timeoutMs));
-
-    const response = await fetch(`${this.baseUrl}/Sessions/${sessionId}/Message?${params}`, {
+    const response = await fetch(`${this.baseUrl}/Sessions/${sessionId}/Message`, {
       method: 'POST',
-      headers: this.buildHeaders(),
+      body: JSON.stringify({ Text: text, Header: header, TimeoutMs: timeoutMs }),
+      headers: {
+        'Content-Type': 'application/json',
+        ...this.buildHeaders(),
+      },
     });
 
     // Best-effort: don't fail if client doesn't support messages or session ended


### PR DESCRIPTION
## Summary

Fixes "Message client" action fail on rule action execution / when stream is terminated.
(Jellyfin's API reply 415 Unsupported Media Type)

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

<!-- Link to issue if applicable. Features should have been discussed first in Discussions or Discord. -->

N/A

## Changes

<!-- What specifically changed? -->

- Replace qs by json body

## Screenshots

N/A 

<!-- For UI changes. Delete this section otherwise. -->

## Testing

- [ ] Added/updated unit tests
- [X] Ran test suite locally (`pnpm test:unit`)
- [X] Tested manually

<!-- If manual testing, describe what you did: -->

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

<!-- If checked, briefly note how (e.g., "generated initial implementation", "helped debug matching logic"): -->

## Checklist

- [X] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [X] Self-reviewed
- [X] No new warnings from `pnpm typecheck`
- [X] Tests pass locally
