### PR TITLE
Add version to public health api

### DIFF
--- a/apps/server/src/routes/public.openapi.ts
+++ b/apps/server/src/routes/public.openapi.ts
@@ -221,6 +221,7 @@ const ServerStatus = z
 const HealthResponse = z
   .object({
     status: z.literal('ok'),
+    version: z.string().openapi({ description: 'Tracearr server version', example: '1.4.22' }),
     timestamp: z.iso.datetime().openapi({ example: '2024-01-15T12:00:00.000Z' }),
     servers: z.array(ServerStatus),
   })

--- a/apps/server/src/routes/public.ts
+++ b/apps/server/src/routes/public.ts
@@ -43,6 +43,7 @@ import { getCacheService } from '../services/cache.js';
 import { getDashboardStats } from '../services/dashboardStats.js';
 import { buildAvatarUrl, buildPosterUrl } from '../services/imageProxy.js';
 import { terminateSession } from '../services/termination.js';
+import { getCurrentVersion } from '../utils/buildInfo.js';
 import { generateOpenAPIDocument } from './public.openapi.js';
 import {
   queryConcurrentStreams,
@@ -252,6 +253,7 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
 
     return {
       status: 'ok',
+      version: getCurrentVersion(),
       timestamp: new Date().toISOString(),
       servers: serverStatus,
     };


### PR DESCRIPTION
## Summary

Adds the current server version to the `/api/v1/public/health` response, enabling version monitoring via tools like release-argus.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

Closes #582

## Changes

- Added `version` field to the health endpoint response, sourced from the existing `buildInfo` utility
- Updated the OpenAPI schema (`HealthResponse`) to document the new field

## Testing

- [ ] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

No existing tests for the public health endpoint. Verified type-check passes. The `getCurrentVersion()` utility is already used elsewhere (debug page, version check job).

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
