### PR TITLE
Use pino err key for error serialization in log calls

### DIFF
--- a/apps/server/src/routes/auth/emby.ts
+++ b/apps/server/src/routes/auth/emby.ts
@@ -91,13 +91,13 @@ export const embyRoutes: FastifyPluginAsync = async (app) => {
           );
         })
         .catch((error) => {
-          app.log.error({ error, serverId }, 'Auto-sync failed for Emby server');
+          app.log.error({ err: error, serverId }, 'Auto-sync failed for Emby server');
         });
 
       // Return updated tokens with new server access
       return generateTokens(app, authUser.userId, authUser.username, authUser.role);
     } catch (error) {
-      app.log.error({ error }, 'Emby connect-api-key failed');
+      app.log.error({ err: error }, 'Emby connect-api-key failed');
       return reply.internalServerError('Failed to connect Emby server');
     }
   });

--- a/apps/server/src/routes/auth/jellyfin.ts
+++ b/apps/server/src/routes/auth/jellyfin.ts
@@ -99,7 +99,7 @@ export const jellyfinRoutes: FastifyPluginAsync = async (app) => {
         'Invalid username or password, or user is not an administrator on any configured Jellyfin server'
       );
     } catch (error) {
-      app.log.error({ error, username }, 'Jellyfin login error');
+      app.log.error({ err: error, username }, 'Jellyfin login error');
       return await reply.internalServerError('Failed to authenticate with Jellyfin servers');
     }
   });
@@ -183,13 +183,13 @@ export const jellyfinRoutes: FastifyPluginAsync = async (app) => {
             );
           })
           .catch((error) => {
-            app.log.error({ error, serverId }, 'Auto-sync failed for Jellyfin server');
+            app.log.error({ err: error, serverId }, 'Auto-sync failed for Jellyfin server');
           });
 
         // Return updated tokens with new server access
         return generateTokens(app, authUser.userId, authUser.username, authUser.role);
       } catch (error) {
-        app.log.error({ error }, 'Jellyfin connect-api-key failed');
+        app.log.error({ err: error }, 'Jellyfin connect-api-key failed');
         return reply.internalServerError('Failed to connect Jellyfin server');
       }
     }

--- a/apps/server/src/routes/auth/local.ts
+++ b/apps/server/src/routes/auth/local.ts
@@ -171,7 +171,7 @@ export const localRoutes: FastifyPluginAsync = async (app) => {
         const { pinId, authUrl } = await PlexClient.initiateOAuth(forwardUrl);
         return { pinId, authUrl };
       } catch (error) {
-        app.log.error({ error }, 'Failed to initiate Plex OAuth');
+        app.log.error({ err: error }, 'Failed to initiate Plex OAuth');
         return reply.internalServerError('Failed to initiate Plex authentication');
       }
     }

--- a/apps/server/src/routes/auth/plex.ts
+++ b/apps/server/src/routes/auth/plex.ts
@@ -391,7 +391,7 @@ export const plexRoutes: FastifyPluginAsync = async (app) => {
         ...(await generateTokens(app, newUser.id, newUser.username, newUser.role)),
       };
     } catch (error) {
-      app.log.error({ error }, 'Plex check-pin failed');
+      app.log.error({ err: error }, 'Plex check-pin failed');
       return reply.internalServerError('Failed to check Plex authorization');
     }
   });
@@ -562,12 +562,12 @@ export const plexRoutes: FastifyPluginAsync = async (app) => {
           );
         })
         .catch((error) => {
-          app.log.error({ error, serverId }, 'Auto-sync failed for Plex server');
+          app.log.error({ err: error, serverId }, 'Auto-sync failed for Plex server');
         });
 
       return generateTokens(app, newUser.id, newUser.username, newUser.role);
     } catch (error) {
-      app.log.error({ error }, 'Plex connect failed');
+      app.log.error({ err: error }, 'Plex connect failed');
       return reply.internalServerError('Failed to connect to Plex server');
     }
   });
@@ -645,7 +645,7 @@ export const plexRoutes: FastifyPluginAsync = async (app) => {
       try {
         allServers = await PlexClient.getServers(plexToken);
       } catch (error) {
-        app.log.error({ error }, 'Failed to fetch servers from plex.tv');
+        app.log.error({ err: error }, 'Failed to fetch servers from plex.tv');
         return reply.internalServerError('Failed to fetch servers from Plex');
       }
 
@@ -732,7 +732,7 @@ export const plexRoutes: FastifyPluginAsync = async (app) => {
       try {
         plexServers = await PlexClient.getServers(existingServer.token);
       } catch (error) {
-        app.log.error({ error }, 'Failed to fetch servers from plex.tv');
+        app.log.error({ err: error }, 'Failed to fetch servers from plex.tv');
         return reply.internalServerError('Failed to fetch servers from Plex');
       }
 
@@ -957,7 +957,10 @@ export const plexRoutes: FastifyPluginAsync = async (app) => {
           );
         })
         .catch((error) => {
-          app.log.error({ error, serverId: newServer.id }, 'Auto-sync failed for new Plex server');
+          app.log.error(
+            { err: error, serverId: newServer.id },
+            'Auto-sync failed for new Plex server'
+          );
         });
 
       return {
@@ -970,7 +973,7 @@ export const plexRoutes: FastifyPluginAsync = async (app) => {
         },
       };
     } catch (error) {
-      app.log.error({ error }, 'Failed to add Plex server');
+      app.log.error({ err: error }, 'Failed to add Plex server');
       return reply.internalServerError('Failed to add Plex server');
     }
   });
@@ -1167,7 +1170,7 @@ export const plexRoutes: FastifyPluginAsync = async (app) => {
           },
         };
       } catch (error) {
-        app.log.error({ error }, 'Failed to link Plex account');
+        app.log.error({ err: error }, 'Failed to link Plex account');
         return reply.internalServerError('Failed to link Plex account');
       }
     }

--- a/apps/server/src/routes/import.ts
+++ b/apps/server/src/routes/import.ts
@@ -60,7 +60,7 @@ export const importRoutes: FastifyPluginAsync = async (app) => {
       await syncServer(serverId, { syncUsers: true, syncLibraries: false });
       app.log.info({ serverId }, 'Server sync completed, enqueueing import');
     } catch (error) {
-      app.log.error({ error, serverId }, 'Failed to sync server before import');
+      app.log.error({ err: error, serverId }, 'Failed to sync server before import');
       return reply.internalServerError('Failed to sync server users before import');
     }
 
@@ -85,7 +85,7 @@ export const importRoutes: FastifyPluginAsync = async (app) => {
       }
 
       // Fallback to direct execution if queue is not available
-      app.log.warn({ error }, 'Import queue unavailable, falling back to direct execution');
+      app.log.warn({ err: error }, 'Import queue unavailable, falling back to direct execution');
 
       const pubSubService = getPubSubService();
 
@@ -329,7 +329,7 @@ export const importRoutes: FastifyPluginAsync = async (app) => {
       await syncServer(parsed.data.serverId, { syncUsers: true, syncLibraries: false });
       app.log.info({ serverId }, 'Server sync completed');
     } catch (error) {
-      app.log.error({ error, serverId }, 'Failed to sync server before import');
+      app.log.error({ err: error, serverId }, 'Failed to sync server before import');
       return reply.internalServerError('Failed to sync server users before import');
     }
 
@@ -355,7 +355,7 @@ export const importRoutes: FastifyPluginAsync = async (app) => {
       }
 
       // Fallback to direct execution if queue is not available
-      app.log.warn({ error }, 'Import queue unavailable, falling back to direct execution');
+      app.log.warn({ err: error }, 'Import queue unavailable, falling back to direct execution');
 
       const pubSubService = getPubSubService();
 

--- a/apps/server/src/routes/servers.ts
+++ b/apps/server/src/routes/servers.ts
@@ -149,7 +149,7 @@ export const serverRoutes: FastifyPluginAsync = async (app) => {
         }
       }
     } catch (error) {
-      app.log.error({ error }, 'Failed to verify server connection');
+      app.log.error({ err: error }, 'Failed to verify server connection');
       return reply.badRequest('Failed to connect to server. Please verify URL and token.');
     }
 
@@ -199,7 +199,7 @@ export const serverRoutes: FastifyPluginAsync = async (app) => {
         );
       })
       .catch((error) => {
-        app.log.error({ error, serverId: server.id }, 'Auto-sync failed for new server');
+        app.log.error({ err: error, serverId: server.id }, 'Auto-sync failed for new server');
       });
 
     return reply.status(201).send(server);
@@ -294,7 +294,7 @@ export const serverRoutes: FastifyPluginAsync = async (app) => {
             }
           }
         } catch (error) {
-          app.log.error({ error, serverId: id, newUrl }, 'Failed to verify new server URL');
+          app.log.error({ err: error, serverId: id, newUrl }, 'Failed to verify new server URL');
           return reply.badRequest(
             'Failed to connect to server at new URL. Please verify the URL is correct.'
           );
@@ -403,7 +403,7 @@ export const serverRoutes: FastifyPluginAsync = async (app) => {
 
       return { success: true };
     } catch (error) {
-      app.log.error({ error }, 'Failed to update server display order');
+      app.log.error({ err: error }, 'Failed to update server display order');
       return reply.internalServerError('Failed to update server order');
     }
   });
@@ -492,7 +492,7 @@ export const serverRoutes: FastifyPluginAsync = async (app) => {
         syncedAt: new Date().toISOString(),
       };
     } catch (error) {
-      app.log.error({ error, serverId: id }, 'Failed to sync server');
+      app.log.error({ err: error, serverId: id }, 'Failed to sync server');
       return reply.internalServerError('Failed to sync server');
     }
   });
@@ -648,7 +648,7 @@ export const serverRoutes: FastifyPluginAsync = async (app) => {
       reply.header('Cache-Control', 'public, max-age=86400'); // Cache for 24 hours
       return reply.send(Buffer.from(buffer));
     } catch (error) {
-      app.log.error({ error, serverId: id, imagePath }, 'Failed to fetch image from server');
+      app.log.error({ err: error, serverId: id, imagePath }, 'Failed to fetch image from server');
       return reply.internalServerError('Failed to fetch image');
     }
   });


### PR DESCRIPTION
## Summary

Pino only runs its error serializer when the key is `err`. All route-level catch blocks were using `{ error }` which caused errors to serialize as `{}` in logs - losing the message, stack trace, and type entirely. This came up while debugging a user-reported error where the logs were useless.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

None - discovered while debugging a user-reported 500 error with empty error details in logs.

## Changes

- Changed all `{ error }` and `{ error, ...fields }` to `{ err: error }` and `{ err: error, ...fields }` in pino log calls across route handlers
- Covers `log.error()` and `log.warn()` calls in 6 files: plex, jellyfin, emby, local auth, servers, and import routes
- No logic changes - only the serialization key in log call objects

## Testing

- [ ] Added/updated unit tests
- [ ] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Injected a `throw new Error('test')` into a route handler and confirmed the log now outputs the full error with type, message, and stack instead of `{}`.

## AI Disclosure

- [ ] AI tools were used significantly in writing this code

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
