### PR TITLE
fix(server): allow cross-origin embedding for public image proxy and avatar routes

### DIFF
--- a/apps/server/src/routes/__tests__/images.test.ts
+++ b/apps/server/src/routes/__tests__/images.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
+import helmet from '@fastify/helmet';
 import sensible from '@fastify/sensible';
 import { randomUUID } from 'node:crypto';
 
@@ -29,6 +30,12 @@ async function buildTestApp(): Promise<FastifyInstance> {
 
   // Register sensible for HTTP error helpers
   await app.register(sensible);
+  await app.register(helmet, {
+    contentSecurityPolicy: false,
+    crossOriginOpenerPolicy: false,
+    crossOriginEmbedderPolicy: false,
+    originAgentCluster: false,
+  });
 
   // Register routes
   await app.register(imageRoutes, { prefix: '/images' });
@@ -75,6 +82,7 @@ describe('Image Routes', () => {
       expect(response.headers['content-type']).toBe('image/jpeg');
       expect(response.headers['x-cache']).toBe('MISS');
       expect(response.headers['cache-control']).toContain('public');
+      expect(response.headers['cross-origin-resource-policy']).toBe('cross-origin');
       expect(response.rawPayload).toEqual(mockImageData);
 
       // Verify service was called with defaults
@@ -311,6 +319,7 @@ describe('Image Routes', () => {
       expect(response.statusCode).toBe(200);
       expect(response.headers['content-type']).toBe('image/png');
       expect(response.headers['cache-control']).toContain('public');
+      expect(response.headers['cross-origin-resource-policy']).toBe('cross-origin');
       expect(response.rawPayload).toEqual(mockImageData);
 
       expect(mockProxyImage).toHaveBeenCalledWith({
@@ -367,6 +376,7 @@ describe('Image Routes', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.headers['cache-control']).toContain('public');
+      expect(response.headers['cross-origin-resource-policy']).toBe('cross-origin');
 
       expect(mockProxyImage).toHaveBeenCalledWith({
         serverId: 'fallback',

--- a/apps/server/src/routes/images.ts
+++ b/apps/server/src/routes/images.ts
@@ -81,6 +81,8 @@ export const imageRoutes: FastifyPluginAsync = async (app) => {
       reply.header('X-Cache', 'MISS');
     }
 
+    // Allow public proxy images to be embedded by third-party dashboards.
+    reply.header('Cross-Origin-Resource-Policy', 'cross-origin');
     // Cache for 1 hour in browser, allow CDN caching
     reply.header('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400');
     reply.header('Content-Type', result.contentType);
@@ -115,6 +117,7 @@ export const imageRoutes: FastifyPluginAsync = async (app) => {
         fallback: 'avatar',
       });
 
+      reply.header('Cross-Origin-Resource-Policy', 'cross-origin');
       reply.header('Cache-Control', 'public, max-age=3600');
       reply.header('Content-Type', result.contentType);
       return reply.send(result.data);
@@ -129,6 +132,7 @@ export const imageRoutes: FastifyPluginAsync = async (app) => {
       fallback: 'avatar',
     });
 
+    reply.header('Cross-Origin-Resource-Policy', 'cross-origin');
     reply.header('Cache-Control', 'public, max-age=86400');
     reply.header('Content-Type', result.contentType);
     return reply.send(result.data);


### PR DESCRIPTION
## Summary

Allow cross-origin embedding for public image responses by setting `Cross-Origin-Resource-Policy: cross-origin` on the public image proxy and avatar routes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

Closes #

## Changes

- Set `Cross-Origin-Resource-Policy: cross-origin` for `/api/v1/images/proxy`
- Set `Cross-Origin-Resource-Policy: cross-origin` for `/api/v1/images/avatar`, including fallback avatar responses
- Updated route tests to verify the expected CORP header for the public image routes

## Testing

- [x] Added/updated unit tests
- [ ] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Manual testing:
- Ran `corepack pnpm --filter @tracearr/server exec vitest run --config vitest.routes.config.ts src/routes/__tests__/images.test.ts`
- Verified `src/routes/__tests__/images.test.ts` passes with `16/16` tests
- Ran `corepack pnpm --filter @tracearr/server exec eslint src/routes/images.ts src/routes/__tests__/images.test.ts`

## AI Disclosure

- [x] AI tools were used significantly in writing this code

Used AI to help implement the route change, update the tests, and validate the targeted local checks.

## Checklist

- [ ] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [ ] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
