### PR TITLE
Add library items and stable IDs to the public API for third-party matching

### DIFF
--- a/apps/server/src/routes/__tests__/public.test.ts
+++ b/apps/server/src/routes/__tests__/public.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import sensible from '@fastify/sensible';
+import { randomUUID } from 'node:crypto';
+
+vi.mock('../../db/client.js', () => ({
+  db: {
+    execute: vi.fn(),
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/cache.js', () => ({
+  getCacheService: vi.fn(),
+}));
+
+vi.mock('../../services/dashboardStats.js', () => ({
+  getDashboardStats: vi.fn(),
+}));
+
+vi.mock('../../services/imageProxy.js', () => ({
+  buildAvatarUrl: vi.fn((serverId: string, path: string | null) =>
+    path ? `avatar:${serverId}:${path}` : null
+  ),
+  buildPosterUrl: vi.fn((serverId: string, path: string | null) =>
+    path ? `poster:${serverId}:${path}` : null
+  ),
+}));
+
+vi.mock('../../services/termination.js', () => ({
+  terminateSession: vi.fn(),
+}));
+
+vi.mock('../../utils/buildInfo.js', () => ({
+  getCurrentVersion: vi.fn(() => '1.0.0-test'),
+}));
+
+vi.mock('../stats/queries.js', () => ({
+  queryConcurrentStreams: vi.fn(),
+  queryPlatforms: vi.fn(),
+  queryPlaysByDayOfWeek: vi.fn(),
+  queryPlaysByHourOfDay: vi.fn(),
+  queryPlaysOverTime: vi.fn(),
+  queryQualityBreakdown: vi.fn(),
+}));
+
+import { db } from '../../db/client.js';
+import { publicRoutes } from '../public.js';
+import { generateOpenAPIDocument } from '../public.openapi.js';
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(sensible);
+  app.decorate(
+    'authenticatePublicApi',
+    vi.fn(async (request: unknown) => {
+      void request;
+    })
+  );
+  await app.register(publicRoutes, { prefix: '/public' });
+  return app;
+}
+
+describe('Public API Routes', () => {
+  let app: FastifyInstance;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('returns stable media IDs and parent show IDs from /history', async () => {
+    app = await buildTestApp();
+
+    const serverId = randomUUID();
+    const userId = randomUUID();
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce({ rows: [{ count: 1 }] } as never)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: randomUUID(),
+            started_at: new Date('2026-04-07T10:00:00.000Z'),
+            stopped_at: new Date('2026-04-07T10:25:00.000Z'),
+            duration_ms: '1500000',
+            progress_ms: 1450000,
+            total_duration_ms: 1800000,
+            segment_count: '2',
+            watched: true,
+            state: 'stopped',
+            server_id: serverId,
+            server_name: 'Main Plex',
+            media_type: 'episode',
+            media_title: 'Pilot',
+            grandparent_title: 'Breaking Bad',
+            season_number: 1,
+            episode_number: 1,
+            year: 2008,
+            artist_name: null,
+            album_name: null,
+            track_number: null,
+            disc_number: null,
+            thumb_path: '/library/metadata/1/thumb/1',
+            rating_key: 'ep-123',
+            device: 'Chrome',
+            player_name: 'Web',
+            product: 'Plex Web',
+            platform: 'Chrome',
+            is_transcode: false,
+            video_decision: 'copy',
+            audio_decision: 'copy',
+            bitrate: 8000,
+            source_video_codec: 'h264',
+            source_audio_codec: 'aac',
+            source_audio_channels: 2,
+            source_video_width: 1920,
+            source_video_height: 1080,
+            source_video_details: null,
+            source_audio_details: null,
+            stream_video_codec: 'h264',
+            stream_audio_codec: 'aac',
+            stream_video_details: null,
+            stream_audio_details: null,
+            transcode_info: null,
+            subtitle_info: null,
+            imdb_id: 'tt0959621',
+            tmdb_id: 62085,
+            tvdb_id: 349232,
+            show_rating_key: 'show-456',
+            show_imdb_id: 'tt0903747',
+            show_tmdb_id: 1396,
+            show_tvdb_id: 81189,
+            user_id: userId,
+            server_username: 'jared',
+            user_thumb_url: '/users/1/avatar',
+            user_name: 'Jared',
+            user_username: 'jared',
+          },
+        ],
+      } as never);
+
+    const response = await app.inject({ method: 'GET', url: '/public/history?page=1&pageSize=25' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.meta).toEqual({ page: 1, pageSize: 25, total: 1 });
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).toMatchObject({
+      ratingKey: 'ep-123',
+      imdbId: 'tt0959621',
+      tmdbId: 62085,
+      tvdbId: 349232,
+      showRatingKey: 'show-456',
+      showImdbId: 'tt0903747',
+      showTmdbId: 1396,
+      showTvdbId: 81189,
+      showTitle: 'Breaking Bad',
+      user: {
+        id: userId,
+        username: 'Jared',
+        avatarUrl: `avatar:${serverId}:/users/1/avatar`,
+      },
+      posterUrl: `poster:${serverId}:/library/metadata/1/thumb/1`,
+    });
+  });
+
+  it('returns stable IDs from /library/items', async () => {
+    app = await buildTestApp();
+
+    const serverId = randomUUID();
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce({ rows: [{ count: 1 }] } as never)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: randomUUID(),
+            server_id: serverId,
+            server_name: 'Main Plex',
+            library_id: 'movie-library',
+            rating_key: 'movie-123',
+            imdb_id: 'tt1375666',
+            tmdb_id: 27205,
+            tvdb_id: 12345,
+            title: 'Inception',
+            media_type: 'movie',
+            year: 2010,
+            grandparent_title: null,
+            grandparent_rating_key: null,
+            parent_title: null,
+            parent_rating_key: null,
+            parent_index: null,
+            item_index: null,
+            created_at: new Date('2026-04-06T00:00:00.000Z'),
+            updated_at: new Date('2026-04-07T00:00:00.000Z'),
+          },
+        ],
+      } as never);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/public/library/items?page=1&pageSize=25&mediaType=movie',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.meta).toEqual({ page: 1, pageSize: 25, total: 1 });
+    expect(body.data[0]).toMatchObject({
+      serverId,
+      serverName: 'Main Plex',
+      libraryId: 'movie-library',
+      ratingKey: 'movie-123',
+      imdbId: 'tt1375666',
+      tmdbId: 27205,
+      tvdbId: 12345,
+      title: 'Inception',
+      mediaType: 'movie',
+      year: 2010,
+    });
+  });
+});
+
+describe('Public API OpenAPI document', () => {
+  it('documents the public library items endpoint and stable history IDs', () => {
+    const doc = generateOpenAPIDocument() as {
+      paths: Record<string, { get?: unknown }>;
+      components: {
+        schemas: Record<string, { properties?: Record<string, unknown> }>;
+      };
+    };
+
+    expect(doc.paths['/api/v1/public/library/items']?.get).toBeTruthy();
+    expect(doc.paths['/api/v1/public/history']?.get).toBeTruthy();
+
+    const sessionHistoryProperties = doc.components.schemas.SessionHistory?.properties ?? {};
+    expect(sessionHistoryProperties).toHaveProperty('ratingKey');
+    expect(sessionHistoryProperties).toHaveProperty('imdbId');
+    expect(sessionHistoryProperties).toHaveProperty('tmdbId');
+    expect(sessionHistoryProperties).toHaveProperty('tvdbId');
+    expect(sessionHistoryProperties).toHaveProperty('showRatingKey');
+    expect(sessionHistoryProperties).toHaveProperty('showImdbId');
+    expect(sessionHistoryProperties).toHaveProperty('showTmdbId');
+    expect(sessionHistoryProperties).toHaveProperty('showTvdbId');
+
+    const libraryItemProperties = doc.components.schemas.LibraryItem?.properties ?? {};
+    expect(libraryItemProperties).toHaveProperty('ratingKey');
+    expect(libraryItemProperties).toHaveProperty('imdbId');
+    expect(libraryItemProperties).toHaveProperty('tmdbId');
+    expect(libraryItemProperties).toHaveProperty('tvdbId');
+  });
+});

--- a/apps/server/src/routes/public.openapi.ts
+++ b/apps/server/src/routes/public.openapi.ts
@@ -78,6 +78,10 @@ const UserInfo = z.object({
 const MediaInfo = z.object({
   mediaTitle: z.string().openapi({ example: 'Inception' }),
   mediaType: MediaTypeEnum,
+  ratingKey: z
+    .string()
+    .nullable()
+    .openapi({ description: 'Server-specific media identifier', example: '12345' }),
   showTitle: z
     .string()
     .nullable()
@@ -85,17 +89,28 @@ const MediaInfo = z.object({
   seasonNumber: z.number().int().nullable().openapi({ example: 5 }),
   episodeNumber: z.number().int().nullable().openapi({ example: 16 }),
   year: z.number().int().nullable().openapi({ example: 2010 }),
+  imdbId: z
+    .string()
+    .nullable()
+    .openapi({ description: 'IMDb identifier when available', example: 'tt1375666' }),
+  tmdbId: z
+    .number()
+    .int()
+    .nullable()
+    .openapi({ description: 'TMDb identifier when available', example: 27205 }),
+  tvdbId: z
+    .number()
+    .int()
+    .nullable()
+    .openapi({ description: 'TVDb identifier when available', example: 80379 }),
   artistName: z
     .string()
     .nullable()
     .openapi({ description: 'Artist name (music tracks only)', example: 'Pink Floyd' }),
-  albumName: z
-    .string()
-    .nullable()
-    .openapi({
-      description: 'Album name (music tracks only)',
-      example: 'The Dark Side of the Moon',
-    }),
+  albumName: z.string().nullable().openapi({
+    description: 'Album name (music tracks only)',
+    example: 'The Dark Side of the Moon',
+  }),
   trackNumber: z
     .number()
     .int()

--- a/apps/server/src/routes/public.openapi.ts
+++ b/apps/server/src/routes/public.openapi.ts
@@ -103,6 +103,36 @@ const MediaInfo = z.object({
     .int()
     .nullable()
     .openapi({ description: 'TVDb identifier when available', example: 80379 }),
+  showRatingKey: z
+    .string()
+    .nullable()
+    .openapi({
+      description: 'Parent show server identifier for episode history rows',
+      example: '54321',
+    }),
+  showImdbId: z
+    .string()
+    .nullable()
+    .openapi({
+      description: 'Parent show IMDb identifier for episode history rows',
+      example: 'tt1442437',
+    }),
+  showTmdbId: z
+    .number()
+    .int()
+    .nullable()
+    .openapi({
+      description: 'Parent show TMDb identifier for episode history rows',
+      example: 1421,
+    }),
+  showTvdbId: z
+    .number()
+    .int()
+    .nullable()
+    .openapi({
+      description: 'Parent show TVDb identifier for episode history rows',
+      example: 121361,
+    }),
   artistName: z
     .string()
     .nullable()
@@ -794,6 +824,65 @@ registry.registerPath({
     200: {
       description: 'History retrieved',
       content: { 'application/json': { schema: HistoryResponse } },
+    },
+    401: { description: 'Invalid or missing API key' },
+  },
+});
+
+// ============================================================================
+// GET /library/items
+// ============================================================================
+
+const LibraryItemsQuery = PaginationQuery.extend({
+  serverId: ServerIdParam.optional().openapi({ description: 'Filter by server' }),
+  mediaType: z.enum(['movie', 'show', 'episode', 'season', 'track', 'album', 'artist']).optional(),
+});
+
+const LibraryItem = z
+  .object({
+    id: z.uuid(),
+    ...ServerInfo.shape,
+    libraryId: z.string().openapi({ example: '1' }),
+    ratingKey: z.string().openapi({ example: '12345' }),
+    imdbId: z.string().nullable().openapi({ example: 'tt1375666' }),
+    tmdbId: z.number().int().nullable().openapi({ example: 27205 }),
+    tvdbId: z.number().int().nullable().openapi({ example: 80379 }),
+    title: z.string().openapi({ example: 'Inception' }),
+    mediaType: z
+      .enum(['movie', 'show', 'episode', 'season', 'track', 'album', 'artist'])
+      .openapi({ example: 'movie' }),
+    year: z.number().int().nullable().openapi({ example: 2010 }),
+    grandparentTitle: z.string().nullable().openapi({ example: 'Breaking Bad' }),
+    grandparentRatingKey: z.string().nullable().openapi({ example: '54321' }),
+    parentTitle: z.string().nullable().openapi({ example: 'Season 5' }),
+    parentRatingKey: z.string().nullable().openapi({ example: '67890' }),
+    parentIndex: z.number().int().nullable().openapi({ example: 5 }),
+    itemIndex: z.number().int().nullable().openapi({ example: 16 }),
+    createdAt: z.iso.datetime(),
+    updatedAt: z.iso.datetime(),
+  })
+  .openapi('LibraryItem');
+
+const LibraryItemsResponse = z
+  .object({
+    data: z.array(LibraryItem),
+    meta: PaginationMeta,
+  })
+  .openapi('LibraryItemsResponse');
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/public/library/items',
+  tags: ['Public API'],
+  summary: 'Library items',
+  description:
+    'Paginated current library items with stable provider IDs for third-party integrations.',
+  security: [{ bearerAuth: [] }],
+  request: { query: LibraryItemsQuery },
+  responses: {
+    200: {
+      description: 'Library items retrieved',
+      content: { 'application/json': { schema: LibraryItemsResponse } },
     },
     401: { description: 'Invalid or missing API key' },
   },

--- a/apps/server/src/routes/public.ts
+++ b/apps/server/src/routes/public.ts
@@ -766,6 +766,10 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
         li.imdb_id,
         li.tmdb_id,
         li.tvdb_id,
+        show_li.rating_key as show_rating_key,
+        show_li.imdb_id as show_imdb_id,
+        show_li.tmdb_id as show_tmdb_id,
+        show_li.tvdb_id as show_tvdb_id,
         su.user_id,
         su.username as server_username,
         su.thumb_url as user_thumb_url,
@@ -776,6 +780,9 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
       LEFT JOIN library_items li
         ON li.server_id = s.server_id
        AND li.rating_key = s.rating_key
+      LEFT JOIN library_items show_li
+        ON show_li.server_id = li.server_id
+       AND show_li.rating_key = li.grandparent_rating_key
       JOIN server_users su ON su.id = s.server_user_id
       JOIN servers sv ON sv.id = s.server_id
       LEFT JOIN users u ON u.id = su.user_id
@@ -832,6 +839,10 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
         imdb_id: string | null;
         tmdb_id: number | null;
         tvdb_id: number | null;
+        show_rating_key: string | null;
+        show_imdb_id: string | null;
+        show_tmdb_id: number | null;
+        show_tvdb_id: number | null;
         user_id: string;
         server_username: string;
         user_thumb_url: string | null;
@@ -853,6 +864,10 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
       imdbId: row.imdb_id,
       tmdbId: row.tmdb_id,
       tvdbId: row.tvdb_id,
+      showRatingKey: row.show_rating_key,
+      showImdbId: row.show_imdb_id,
+      showTmdbId: row.show_tmdb_id,
+      showTvdbId: row.show_tvdb_id,
       artistName: row.artist_name,
       albumName: row.album_name,
       trackNumber: row.track_number,
@@ -1000,6 +1015,114 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
       platforms,
       quality,
     };
+  });
+
+  /**
+   * GET /library/items - Current library items with stable IDs for third-party integrations
+   */
+  app.get('/library/items', { preHandler: [app.authenticatePublicApi] }, async (request, reply) => {
+    const querySchema = paginationSchema.extend({
+      serverId: z.uuid().optional(),
+      mediaType: z
+        .enum(['movie', 'show', 'episode', 'season', 'track', 'album', 'artist'])
+        .optional(),
+    });
+
+    const query = querySchema.safeParse(request.query);
+    if (!query.success) {
+      return reply.badRequest('Invalid query parameters');
+    }
+
+    const { page, pageSize, serverId, mediaType } = query.data;
+    const offset = (page - 1) * pageSize;
+    const conditions: ReturnType<typeof sql>[] = [];
+    if (serverId) conditions.push(sql`li.server_id = ${serverId}`);
+    if (mediaType) conditions.push(sql`li.media_type = ${mediaType}`);
+    const whereClause =
+      conditions.length > 0 ? sql`WHERE ${sql.join(conditions, sql` AND `)}` : sql``;
+
+    const countResult = await db.execute(sql`
+      SELECT COUNT(*)::int AS count
+      FROM library_items li
+      ${whereClause}
+    `);
+    const total = (countResult.rows[0] as { count: number } | undefined)?.count ?? 0;
+
+    const result = await db.execute(sql`
+      SELECT
+        li.id,
+        li.server_id,
+        sv.name AS server_name,
+        li.library_id,
+        li.rating_key,
+        li.imdb_id,
+        li.tmdb_id,
+        li.tvdb_id,
+        li.title,
+        li.media_type,
+        li.year,
+        li.grandparent_title,
+        li.grandparent_rating_key,
+        li.parent_title,
+        li.parent_rating_key,
+        li.parent_index,
+        li.item_index,
+        li.created_at,
+        li.updated_at
+      FROM library_items li
+      JOIN servers sv ON sv.id = li.server_id
+      ${whereClause}
+      ORDER BY li.updated_at DESC, li.created_at DESC, li.id DESC
+      LIMIT ${pageSize} OFFSET ${offset}
+    `);
+
+    const rows = (
+      result.rows as {
+        id: string;
+        server_id: string;
+        server_name: string;
+        library_id: string;
+        rating_key: string;
+        imdb_id: string | null;
+        tmdb_id: number | null;
+        tvdb_id: number | null;
+        title: string;
+        media_type: string;
+        year: number | null;
+        grandparent_title: string | null;
+        grandparent_rating_key: string | null;
+        parent_title: string | null;
+        parent_rating_key: string | null;
+        parent_index: number | null;
+        item_index: number | null;
+        created_at: Date;
+        updated_at: Date;
+      }[]
+    ).map((row) => ({
+      id: row.id,
+      serverId: row.server_id,
+      serverName: row.server_name,
+      libraryId: row.library_id,
+      ratingKey: row.rating_key,
+      imdbId: row.imdb_id,
+      tmdbId: row.tmdb_id,
+      tvdbId: row.tvdb_id,
+      title: row.title,
+      mediaType: row.media_type,
+      year: row.year,
+      grandparentTitle: row.grandparent_title,
+      grandparentRatingKey: row.grandparent_rating_key,
+      parentTitle: row.parent_title,
+      parentRatingKey: row.parent_rating_key,
+      parentIndex: row.parent_index,
+      itemIndex: row.item_index,
+      createdAt:
+        row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+      updatedAt:
+        row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at),
+    }));
+
+    return paginatedResponse(rows, total, page, pageSize);
   });
 
   /**

--- a/apps/server/src/routes/public.ts
+++ b/apps/server/src/routes/public.ts
@@ -741,6 +741,7 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
         s.track_number,
         s.disc_number,
         s.thumb_path,
+        s.rating_key,
         s.device,
         s.player_name,
         s.product,
@@ -762,6 +763,9 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
         s.stream_audio_details,
         s.transcode_info,
         s.subtitle_info,
+        li.imdb_id,
+        li.tmdb_id,
+        li.tvdb_id,
         su.user_id,
         su.username as server_username,
         su.thumb_url as user_thumb_url,
@@ -769,6 +773,9 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
         u.username as user_username
       FROM grouped_sessions gs
       JOIN sessions s ON s.id = gs.first_session_id
+      LEFT JOIN library_items li
+        ON li.server_id = s.server_id
+       AND li.rating_key = s.rating_key
       JOIN server_users su ON su.id = s.server_user_id
       JOIN servers sv ON sv.id = s.server_id
       LEFT JOIN users u ON u.id = su.user_id
@@ -800,6 +807,7 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
         track_number: number | null;
         disc_number: number | null;
         thumb_path: string | null;
+        rating_key: string | null;
         device: string | null;
         player_name: string | null;
         product: string | null;
@@ -821,6 +829,9 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
         stream_audio_details: StreamAudioDetails | null;
         transcode_info: TranscodeInfo | null;
         subtitle_info: SubtitleInfo | null;
+        imdb_id: string | null;
+        tmdb_id: number | null;
+        tvdb_id: number | null;
         user_id: string;
         server_username: string;
         user_thumb_url: string | null;
@@ -838,6 +849,10 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
       seasonNumber: row.season_number,
       episodeNumber: row.episode_number,
       year: row.year,
+      ratingKey: row.rating_key,
+      imdbId: row.imdb_id,
+      tmdbId: row.tmdb_id,
+      tvdbId: row.tvdb_id,
       artistName: row.artist_name,
       albumName: row.album_name,
       trackNumber: row.track_number,


### PR DESCRIPTION
## Summary

Expands the public API so third-party integrations can match Tracearr history and library items back to exact media entries more reliably. Discussed in Discord before opening this PR.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Breaking change

## Changes

- Added GET /api/v1/public/library/items
- Added stable IDs to GET /api/v1/public/history: ratingKey, imdbId, tmdbId, tvdbId
- Added parent show IDs on episode history rows: showRatingKey, showImdbId, showTmdbId, showTvdbId
- Updated the public OpenAPI schema for the new endpoint and response fields
- Added focused route tests covering the new public API behavior

## Testing

- [x] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Manual testing:
- Ran `pnpm lint`
- Ran `pnpm typecheck`
- Ran `pnpm test:unit`
- Ran `pnpm test:services`
- Ran `pnpm test:routes`
- Ran `pnpm test:security`
- Ran `pnpm test:integration`
- Ran `pnpm test:coverage`
- Ran `pnpm translations:check`
- Ran Playwright e2e locally against the Docker-backed test DB/Redis stack

## AI Disclosure

- [x] AI tools were used significantly in writing this code

Used to help implement and debug the API changes, then reviewed and validated manually with the full local test suite.

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally