### PR TITLE
Enhance Discord embeds with images and consistent information

### DIFF
--- a/apps/server/src/services/notifications/agents/base.ts
+++ b/apps/server/src/services/notifications/agents/base.ts
@@ -13,6 +13,7 @@ import type {
   TestResult,
   ActiveSession,
 } from '../types.js';
+import type { ServerUser } from '@tracearr/shared';
 
 /**
  * Abstract base class that all notification agents should extend.
@@ -29,7 +30,11 @@ export abstract class BaseAgent implements NotificationAgent {
   /**
    * Format duration in milliseconds to human-readable string
    */
-  protected formatDuration(ms: number): string {
+  protected formatDuration(ms: number | null): string {
+    if (ms === null || ms === undefined) {
+      return 'Unknown';
+    }
+
     const seconds = Math.floor(ms / 1000);
     const minutes = Math.floor(seconds / 60);
     const hours = Math.floor(minutes / 60);
@@ -83,6 +88,70 @@ export abstract class BaseAgent implements NotificationAgent {
    */
   protected getUserDisplayName(session: ActiveSession): string {
     return session.user.identityName ?? session.user.username;
+  }
+
+  /**
+   * Get the image URL of the user's avatar / thumbnail
+   */
+  protected getUserAvatarURL(user: Pick<ServerUser, 'thumbUrl'>): string | undefined {
+    return user.thumbUrl ? user.thumbUrl : undefined;
+  }
+
+  /**
+   * Get the image URL for the media's thumbnail
+   */
+  protected getMediaPosterURL(
+    session: ActiveSession,
+    netSettings: { externalUrl: string | null }
+  ): string | undefined {
+    if (!netSettings.externalUrl || !session.thumbPath) {
+      return undefined;
+    }
+
+    const url = new URL('/api/v1/images/proxy', netSettings.externalUrl);
+
+    url.searchParams.set('server', session.server.id);
+    url.searchParams.set('url', session.thumbPath);
+    url.searchParams.set('fallback', 'poster');
+
+    return url.toString();
+  }
+
+  /**
+   * Get the image URL for the server's icon
+   */
+  protected getServerIconURL(
+    server: string | undefined,
+    external: string | null
+  ): string | undefined {
+    if (server && external) {
+      switch (server) {
+        case 'plex':
+          return `${external}/images/servers/plex.png`;
+        case 'jellyfin':
+          return `${external}/images/servers/jellyfin.png`;
+        case 'emby':
+          return `${external}/images/servers/emby.png`;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Get the integer value for the server's color
+   */
+  protected getServerColorForDiscord(server: string | undefined): number {
+    switch (server) {
+      case 'plex':
+        return 15445760; // Plex Gold (https://brand.plex.tv/document/439975#/visual/color)
+      case 'jellyfin':
+        return 11164867; // Jellyfin Purple (https://jellyfin.org/docs/general/contributing/branding/#logo)
+      case 'emby':
+        return 5419850; // Emby Green (https://emby.media/resources/logowhite_1881.png)
+      default:
+        return 0x3498db; // Generic Blue
+    }
   }
 
   /**

--- a/apps/server/src/services/notifications/agents/discord.ts
+++ b/apps/server/src/services/notifications/agents/discord.ts
@@ -17,18 +17,55 @@ import type {
   NewDeviceContext,
   TrustScoreChangedContext,
 } from '../types.js';
-import {
-  formatViolationDetailsForDiscord,
-  getSeverityInfo,
-  type DiscordField,
-} from '../formatters/violation.js';
+import { formatViolationDetailsForDiscord, getSeverityInfo } from '../formatters/violation.js';
+import { getNetworkSettings } from '../../settings.js';
 
+/**
+ * @see https://docs.discord.com/developers/resources/message#embed-object
+ */
 interface DiscordEmbed {
-  title: string;
+  title?: string;
   description?: string;
-  color: number;
-  fields?: DiscordField[];
   timestamp?: string;
+  color?: number;
+  footer?: DiscordEmbedFooter;
+  thumbnail?: DiscordEmbedImage;
+  author?: DiscordEmbedAuthor;
+  fields?: DiscordEmbedField[];
+}
+
+/**
+ * @see https://docs.discord.com/developers/resources/message#embed-object-embed-footer-structure
+ */
+interface DiscordEmbedFooter {
+  text: string;
+  icon_url?: string;
+}
+
+/**
+ * @see https://docs.discord.com/developers/resources/message#embed-object-embed-image-structure
+ */
+interface DiscordEmbedImage {
+  url: string;
+  description?: string;
+}
+
+/**
+ * @see https://docs.discord.com/developers/resources/message#embed-object-embed-author-structure
+ */
+interface DiscordEmbedAuthor {
+  name: string;
+  url?: string;
+  icon_url?: string;
+}
+
+/**
+ * @see https://docs.discord.com/developers/resources/message#embed-object-embed-field-structure
+ */
+export interface DiscordEmbedField {
+  name: string;
+  value: string;
+  inline?: boolean;
 }
 
 export class DiscordAgent extends BaseAgent {
@@ -45,7 +82,7 @@ export class DiscordAgent extends BaseAgent {
     }
 
     try {
-      const embed = this.buildEmbed(payload);
+      const embed = await this.buildEmbed(payload);
       await this.sendWebhook(settings.discordWebhookUrl, embed);
       return this.successResult();
     } catch (error) {
@@ -71,194 +108,206 @@ export class DiscordAgent extends BaseAgent {
     }
   }
 
-  private buildEmbed(payload: NotificationPayload): DiscordEmbed {
+  private async buildEmbed(payload: NotificationPayload): Promise<DiscordEmbed> {
     switch (payload.context.type) {
       case 'violation_detected':
-        return this.buildViolationEmbed(payload, payload.context);
+        return await this.buildViolationEmbed(payload, payload.context);
       case 'stream_started':
-        return this.buildSessionStartedEmbed(payload, payload.context);
+        return await this.buildSessionStartedEmbed(payload, payload.context);
       case 'stream_stopped':
-        return this.buildSessionStoppedEmbed(payload, payload.context);
+        return await this.buildSessionStoppedEmbed(payload, payload.context);
       case 'server_down':
-        return this.buildServerDownEmbed(payload, payload.context);
+        return await this.buildServerDownEmbed(payload, payload.context);
       case 'server_up':
-        return this.buildServerUpEmbed(payload, payload.context);
+        return await this.buildServerUpEmbed(payload, payload.context);
       case 'new_device':
-        return this.buildNewDeviceEmbed(payload, payload.context);
+        return await this.buildNewDeviceEmbed(payload, payload.context);
       case 'trust_score_changed':
-        return this.buildTrustScoreChangedEmbed(payload, payload.context);
+        return await this.buildTrustScoreChangedEmbed(payload, payload.context);
     }
   }
 
-  private buildViolationEmbed(_payload: NotificationPayload, ctx: ViolationContext): DiscordEmbed {
+  private async buildViolationEmbed(
+    _payload: NotificationPayload,
+    ctx: ViolationContext
+  ): Promise<DiscordEmbed> {
     const { violation } = ctx;
     const { label: severityLabel, color } = getSeverityInfo(violation.severity);
+    const netSettings = await getNetworkSettings();
     const detailFields = formatViolationDetailsForDiscord(violation.rule.type, violation.data);
 
     return {
+      color: color,
+      author: {
+        name: violation.user.identityName ?? violation.user.username,
+        icon_url: violation.user.thumbUrl ? violation.user.thumbUrl : undefined,
+      },
       title: 'Violation Detected',
-      color,
       fields: [
-        {
-          name: 'User',
-          value: violation.user.identityName ?? violation.user.username,
-          inline: true,
-        },
-        {
-          name: 'Rule',
-          value: violation.rule.name,
-          inline: true,
-        },
-        {
-          name: 'Severity',
-          value: severityLabel,
-          inline: true,
-        },
+        { name: 'Rule', value: violation.rule.name, inline: true },
+        { name: 'Severity', value: severityLabel, inline: true },
         ...detailFields,
       ],
+      footer: {
+        text: ctx.violation.server?.name ?? 'Unknown Server',
+        icon_url: this.getServerIconURL(ctx.violation.server?.type, netSettings.externalUrl),
+      },
+      timestamp: new Date().toISOString(),
     };
   }
 
-  private buildSessionStartedEmbed(
+  private async buildSessionStartedEmbed(
     _payload: NotificationPayload,
     ctx: SessionContext
-  ): DiscordEmbed {
+  ): Promise<DiscordEmbed> {
     const { session } = ctx;
-    const { title: mediaTitle, subtitle } = this.getMediaDisplay(session);
-    const playbackType = this.getPlaybackType(session);
-
-    const fields: DiscordField[] = [
-      {
-        name: 'User',
-        value: this.getUserDisplayName(session),
-        inline: true,
-      },
-      {
-        name: 'Media',
-        value: mediaTitle,
-        inline: true,
-      },
-    ];
-
-    if (subtitle) {
-      fields.push({ name: 'Episode', value: subtitle, inline: true });
-    }
-
-    fields.push({ name: 'Playback', value: playbackType, inline: true });
-
-    if (session.geoCity && session.geoCountry) {
-      fields.push({
-        name: 'Location',
-        value: `${session.geoCity}, ${session.geoCountry}`,
-        inline: true,
-      });
-    }
-
-    fields.push({
-      name: 'Player',
-      value: session.product || session.playerName || 'Unknown',
-      inline: true,
-    });
+    const { title, subtitle } = this.getMediaDisplay(session);
+    const netSettings = await getNetworkSettings();
+    const poster = this.getMediaPosterURL(session, netSettings);
 
     return {
-      title: 'Stream Started',
-      color: 0x3498db, // Blue
-      fields,
+      color: this.getServerColorForDiscord(session.server.type),
+      author: {
+        name: this.getUserDisplayName(session),
+        icon_url: this.getUserAvatarURL(session.user),
+      },
+      title: 'Now Playing',
+      thumbnail: poster ? { url: poster, description: `Artwork for ${title}.` } : undefined,
+      description: subtitle ? `### ${title}\n**${subtitle}**` : `### ${title}`,
+      fields: [
+        { name: 'Playback', value: this.getPlaybackType(session), inline: true },
+        { name: 'Player', value: session.product || session.device || 'Unknown', inline: true },
+        {
+          name: 'Location',
+          value: session.geoCity || session.geoCountry || 'Unknown',
+          inline: true,
+        },
+      ],
+      footer: {
+        text: session.server.name,
+        icon_url: this.getServerIconURL(session.server.type, netSettings.externalUrl),
+      },
+      timestamp: session.startedAt
+        ? new Date(session.startedAt).toISOString()
+        : new Date().toISOString(),
     };
   }
 
-  private buildSessionStoppedEmbed(
+  private async buildSessionStoppedEmbed(
     _payload: NotificationPayload,
     ctx: SessionContext
-  ): DiscordEmbed {
+  ): Promise<DiscordEmbed> {
     const { session } = ctx;
-    const { title: mediaTitle, subtitle } = this.getMediaDisplay(session);
-    const durationStr = session.durationMs ? this.formatDuration(session.durationMs) : 'Unknown';
-
-    const fields: DiscordField[] = [
-      {
-        name: 'User',
-        value: this.getUserDisplayName(session),
-        inline: true,
-      },
-      {
-        name: 'Media',
-        value: mediaTitle,
-        inline: true,
-      },
-    ];
-
-    if (subtitle) {
-      fields.push({ name: 'Episode', value: subtitle, inline: true });
-    }
-
-    fields.push({ name: 'Duration', value: durationStr, inline: true });
+    const { title, subtitle } = this.getMediaDisplay(session);
+    const netSettings = await getNetworkSettings();
+    const poster = this.getMediaPosterURL(session, netSettings);
 
     return {
+      color: this.getServerColorForDiscord(session.server.type),
+      author: {
+        name: this.getUserDisplayName(session),
+        icon_url: this.getUserAvatarURL(session.user),
+      },
       title: 'Stream Ended',
-      color: 0x95a5a6, // Gray
-      fields,
+      thumbnail: poster ? { url: poster, description: `Artwork for ${title}.` } : undefined,
+      description: subtitle ? `### ${title}\n**${subtitle}**` : `### ${title}`,
+      fields: [
+        { name: 'Duration', value: this.formatDuration(session.durationMs), inline: true },
+        { name: 'Player', value: session.product || session.device || 'Unknown', inline: true },
+        {
+          name: 'Location',
+          value: session.geoCity || session.geoCountry || 'Unknown',
+          inline: true,
+        },
+      ],
+      footer: {
+        text: session.server.name,
+        icon_url: this.getServerIconURL(session.server.type, netSettings.externalUrl),
+      },
+      timestamp: session.startedAt
+        ? new Date(session.startedAt).toISOString()
+        : new Date().toISOString(),
     };
   }
 
-  private buildServerDownEmbed(_payload: NotificationPayload, ctx: ServerContext): DiscordEmbed {
+  private async buildServerDownEmbed(
+    _payload: NotificationPayload,
+    ctx: ServerContext
+  ): Promise<DiscordEmbed> {
     return {
-      title: 'Server Connection Lost',
-      description: `Lost connection to ${ctx.serverName}`,
-      color: 0xff0000, // Red
+      color: 0xe74c3c, // Red
+      title: 'Server Offline',
+      footer: {
+        text: ctx.serverName,
+      },
+      timestamp: new Date().toISOString(),
     };
   }
 
-  private buildServerUpEmbed(_payload: NotificationPayload, ctx: ServerContext): DiscordEmbed {
+  private async buildServerUpEmbed(
+    _payload: NotificationPayload,
+    ctx: ServerContext
+  ): Promise<DiscordEmbed> {
     return {
-      title: 'Server Back Online',
-      description: `${ctx.serverName} is back online`,
       color: 0x2ecc71, // Green
+      title: 'Server Online',
+      footer: {
+        text: ctx.serverName,
+      },
+      timestamp: new Date().toISOString(),
     };
   }
 
-  private buildNewDeviceEmbed(_payload: NotificationPayload, ctx: NewDeviceContext): DiscordEmbed {
-    const fields: DiscordField[] = [
-      { name: 'User', value: ctx.userName, inline: true },
-      { name: 'Device', value: ctx.deviceName, inline: true },
-    ];
-
-    if (ctx.platform) {
-      fields.push({ name: 'Platform', value: ctx.platform, inline: true });
-    }
-
-    if (ctx.location) {
-      fields.push({ name: 'Location', value: ctx.location, inline: true });
-    }
+  private async buildNewDeviceEmbed(
+    _payload: NotificationPayload,
+    ctx: NewDeviceContext
+  ): Promise<DiscordEmbed> {
+    const netSettings = await getNetworkSettings();
 
     return {
+      color: this.getServerColorForDiscord(ctx.server.type),
+      author: {
+        name: ctx.userName,
+        icon_url: this.getUserAvatarURL(ctx.user),
+      },
       title: 'New Device Detected',
-      color: 0xf39c12, // Orange/Warning
-      fields,
+      fields: [
+        { name: 'Device', value: ctx.deviceName || 'Unknown', inline: true },
+        { name: 'Platform', value: ctx.platform || 'Unknown', inline: true },
+        { name: 'Location', value: ctx.location || 'Unknown', inline: true },
+      ],
+      footer: {
+        text: ctx.server.name,
+        icon_url: this.getServerIconURL(ctx.server.type, netSettings.externalUrl),
+      },
+      timestamp: new Date().toISOString(),
     };
   }
 
-  private buildTrustScoreChangedEmbed(
+  private async buildTrustScoreChangedEmbed(
     _payload: NotificationPayload,
     ctx: TrustScoreChangedContext
-  ): DiscordEmbed {
-    const direction = ctx.newScore < ctx.previousScore ? 'decreased' : 'increased';
-    const color = ctx.newScore < ctx.previousScore ? 0xe74c3c : 0x2ecc71; // Red or Green
-
-    const fields: DiscordField[] = [
-      { name: 'User', value: ctx.userName, inline: true },
-      { name: 'Previous Score', value: String(ctx.previousScore), inline: true },
-      { name: 'New Score', value: String(ctx.newScore), inline: true },
-    ];
-
-    if (ctx.reason) {
-      fields.push({ name: 'Reason', value: ctx.reason, inline: false });
-    }
+  ): Promise<DiscordEmbed> {
+    const netSettings = await getNetworkSettings();
+    const direction = ctx.newScore < ctx.previousScore ? 'Decreased' : 'Increased';
 
     return {
-      title: `Trust Score ${direction.charAt(0).toUpperCase() + direction.slice(1)}`,
-      color,
-      fields,
+      color: ctx.newScore < ctx.previousScore ? 0xe74c3c : 0x2ecc71, // Red or Green
+      author: {
+        name: ctx.userName,
+        icon_url: this.getUserAvatarURL(ctx.user),
+      },
+      title: `Trust Score ${direction}`,
+      fields: [
+        { name: 'Previous Score', value: String(ctx.previousScore), inline: true },
+        { name: 'New Score', value: String(ctx.newScore), inline: true },
+        { name: 'Reason', value: ctx.reason || 'Unknown', inline: true },
+      ],
+      footer: {
+        text: ctx.server.name,
+        icon_url: this.getServerIconURL(ctx.server.type, netSettings.externalUrl),
+      },
+      timestamp: new Date().toISOString(),
     };
   }
 

--- a/apps/server/src/services/notifications/formatters/violation.ts
+++ b/apps/server/src/services/notifications/formatters/violation.ts
@@ -9,6 +9,7 @@ import {
   type GroupEvidence,
 } from '@tracearr/shared';
 import type { ViolationWithDetails } from '../types.js';
+import type { DiscordEmbedField } from '../agents/discord.js';
 
 /** Fallback values when rule config doesn't specify */
 export const VIOLATION_DEFAULTS = {
@@ -77,20 +78,14 @@ export function getSeverityInfo(severity: string): { label: string; color: numbe
   };
 }
 
-export interface DiscordField {
-  name: string;
-  value: string;
-  inline?: boolean;
-}
-
 /**
  * Format violation details into Discord embed fields based on rule type
  */
 /**
  * Format evidence from V2 rule evaluation into Discord embed fields.
  */
-function formatEvidenceForDiscord(evidence: GroupEvidence[]): DiscordField[] {
-  const fields: DiscordField[] = [];
+function formatEvidenceForDiscord(evidence: GroupEvidence[]): DiscordEmbedField[] {
+  const fields: DiscordEmbedField[] = [];
 
   for (const group of evidence) {
     const matchedConditions = group.conditions.filter((c) => c.matched);
@@ -118,7 +113,7 @@ function formatEvidenceForDiscord(evidence: GroupEvidence[]): DiscordField[] {
 export function formatViolationDetailsForDiscord(
   ruleType: string | null,
   data: Record<string, unknown> | null
-): DiscordField[] {
+): DiscordEmbedField[] {
   if (!data) return [];
 
   // V2 violations: format from evidence
@@ -138,7 +133,7 @@ export function formatViolationDetailsForDiscord(
         currentLocation?: { lat: number; lon: number };
         previousLocation?: { lat: number; lon: number };
       };
-      const fields: DiscordField[] = [];
+      const fields: DiscordEmbedField[] = [];
 
       if (d.distance != null) {
         fields.push({
@@ -188,7 +183,7 @@ export function formatViolationDetailsForDiscord(
         minRequiredDistance?: number;
         locations?: Array<{ lat: number; lon: number; city?: string; country?: string }>;
       };
-      const fields: DiscordField[] = [];
+      const fields: DiscordEmbedField[] = [];
 
       if (d.locationCount != null) {
         fields.push({
@@ -232,7 +227,7 @@ export function formatViolationDetailsForDiscord(
         maxAllowed?: number;
         streams?: Array<{ title?: string; player?: string }>;
       };
-      const fields: DiscordField[] = [];
+      const fields: DiscordEmbedField[] = [];
 
       fields.push({
         name: 'Streams',
@@ -268,7 +263,7 @@ export function formatViolationDetailsForDiscord(
         windowHours?: number;
         ips?: string[];
       };
-      const fields: DiscordField[] = [];
+      const fields: DiscordEmbedField[] = [];
 
       fields.push({
         name: 'IPs Used',
@@ -294,7 +289,7 @@ export function formatViolationDetailsForDiscord(
         allowedCountries?: string[];
         blockedCountries?: string[];
       };
-      const fields: DiscordField[] = [];
+      const fields: DiscordEmbedField[] = [];
 
       if (d.country || d.countryCode) {
         fields.push({

--- a/apps/server/src/services/notifications/index.ts
+++ b/apps/server/src/services/notifications/index.ts
@@ -13,6 +13,8 @@ import type {
   TestResult,
   ViolationWithDetails,
   ActiveSession,
+  Server,
+  ServerUser,
 } from './types.js';
 import { PayloadBuilders } from './types.js';
 import { createAllAgents } from './agents/index.js';
@@ -179,9 +181,18 @@ export class NotificationManager {
     deviceName: string,
     platform: string | null,
     location: string | null,
+    user: Pick<ServerUser, 'id' | 'username' | 'thumbUrl'> & { identityName: string | null },
+    server: Pick<Server, 'id' | 'name' | 'type'>,
     settings: NotificationSettings
   ): Promise<SendResult[]> {
-    const payload = PayloadBuilders.fromNewDevice(userName, deviceName, platform, location);
+    const payload = PayloadBuilders.fromNewDevice(
+      userName,
+      deviceName,
+      platform,
+      location,
+      user,
+      server
+    );
     return this.sendAll(payload, settings);
   }
 
@@ -193,13 +204,17 @@ export class NotificationManager {
     previousScore: number,
     newScore: number,
     reason: string | null,
+    user: Pick<ServerUser, 'id' | 'username' | 'thumbUrl'> & { identityName: string | null },
+    server: Pick<Server, 'id' | 'name' | 'type'>,
     settings: NotificationSettings
   ): Promise<SendResult[]> {
     const payload = PayloadBuilders.fromTrustScoreChanged(
       userName,
       previousScore,
       newScore,
-      reason
+      reason,
+      user,
+      server
     );
     return this.sendAll(payload, settings);
   }

--- a/apps/server/src/services/notifications/types.ts
+++ b/apps/server/src/services/notifications/types.ts
@@ -4,10 +4,16 @@
  * Based on Jellyseerr's agent pattern for extensible notifications.
  */
 
-import type { ViolationWithDetails, ActiveSession, Settings } from '@tracearr/shared';
+import type {
+  ViolationWithDetails,
+  ActiveSession,
+  Server,
+  ServerUser,
+  Settings,
+} from '@tracearr/shared';
 
 // Re-export for convenience
-export type { ViolationWithDetails, ActiveSession, Settings };
+export type { ViolationWithDetails, ActiveSession, Server, ServerUser, Settings };
 
 /**
  * Notification event types matching NOTIFICATION_EVENTS from shared
@@ -60,6 +66,8 @@ export interface NewDeviceContext {
   deviceName: string;
   platform: string | null;
   location: string | null;
+  user: Pick<ServerUser, 'id' | 'username' | 'thumbUrl'> & { identityName: string | null };
+  server: Pick<Server, 'id' | 'name' | 'type'>;
 }
 
 /**
@@ -68,9 +76,11 @@ export interface NewDeviceContext {
 export interface TrustScoreChangedContext {
   type: 'trust_score_changed';
   userName: string;
+  user: Pick<ServerUser, 'id' | 'username' | 'thumbUrl'> & { identityName: string | null };
   previousScore: number;
   newScore: number;
   reason: string | null;
+  server: Pick<Server, 'id' | 'name' | 'type'>;
 }
 
 /**
@@ -245,7 +255,9 @@ export const PayloadBuilders = {
     userName: string,
     deviceName: string,
     platform: string | null,
-    location: string | null
+    location: string | null,
+    user: Pick<ServerUser, 'id' | 'username' | 'thumbUrl'> & { identityName: string | null },
+    server: Pick<Server, 'id' | 'name' | 'type'>
   ): NotificationPayload {
     const locationStr = location ? ` from ${location}` : '';
     return {
@@ -254,7 +266,7 @@ export const PayloadBuilders = {
       message: `${userName} connected from a new device: ${deviceName}${locationStr}`,
       severity: 'warning',
       timestamp: new Date().toISOString(),
-      context: { type: 'new_device', userName, deviceName, platform, location },
+      context: { type: 'new_device', userName, deviceName, platform, location, user, server },
     };
   },
 
@@ -262,7 +274,9 @@ export const PayloadBuilders = {
     userName: string,
     previousScore: number,
     newScore: number,
-    reason: string | null
+    reason: string | null,
+    user: Pick<ServerUser, 'id' | 'username' | 'thumbUrl'> & { identityName: string | null },
+    server: Pick<Server, 'id' | 'name' | 'type'>
   ): NotificationPayload {
     const direction = newScore < previousScore ? 'decreased' : 'increased';
     const reasonStr = reason ? `: ${reason}` : '';
@@ -272,7 +286,15 @@ export const PayloadBuilders = {
       message: `${userName}'s trust score ${direction} from ${previousScore} to ${newScore}${reasonStr}`,
       severity: newScore < previousScore ? 'warning' : 'low',
       timestamp: new Date().toISOString(),
-      context: { type: 'trust_score_changed', userName, previousScore, newScore, reason },
+      context: {
+        type: 'trust_score_changed',
+        userName,
+        previousScore,
+        newScore,
+        reason,
+        user,
+        server,
+      },
     };
   },
 };


### PR DESCRIPTION
## Summary

Update the Discord Webhook notification system to support external server, user, and media images when available and ensures consistent server and user information across all notification types, resulting in cleaner and more uniform embeds.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Documentation
- [X] Refactor
- [ ] Breaking change

## Screenshots

<img width="1444" height="480" alt="Tracearr_Discord_Example" src="https://github.com/user-attachments/assets/5b9d4b82-d4fd-414e-b14b-b6c6999acf12" />

## Testing

- [ ] Added/updated unit tests
- [X] Ran test suite locally (`pnpm test:unit`)
- [X] Tested manually

Triggered multiple notification types locally to ensure functionality.

## Checklist

- [X] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [X] Self-reviewed
- [X] No new warnings from `pnpm typecheck`
- [X] Tests pass locally
