### PR TITLE
add identifiers to public history #823

### DIFF
--- a/apps/server/src/routes/__tests__/public.test.ts
+++ b/apps/server/src/routes/__tests__/public.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Public API route tests
+ *
+ * Focused coverage for external integration contracts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import sensible from '@fastify/sensible';
+import { randomUUID } from 'node:crypto';
+
+vi.mock('../../db/client.js', () => ({
+  db: {
+    execute: vi.fn(),
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/cache.js', () => ({
+  getCacheService: vi.fn(() => null),
+}));
+
+vi.mock('../../services/dashboardStats.js', () => ({
+  getDashboardStats: vi.fn(),
+}));
+
+vi.mock('../../services/imageProxy.js', () => ({
+  buildAvatarUrl: vi.fn((serverId: string, thumbUrl: string | null) =>
+    thumbUrl ? `/avatar/${serverId}` : null
+  ),
+  buildPosterUrl: vi.fn((serverId: string, thumbPath: string | null) =>
+    thumbPath ? `/poster/${serverId}` : null
+  ),
+}));
+
+vi.mock('../../services/termination.js', () => ({
+  terminateSession: vi.fn(),
+}));
+
+vi.mock('../../utils/buildInfo.js', () => ({
+  getCurrentVersion: vi.fn(() => 'test-version'),
+}));
+
+vi.mock('../stats/queries.js', () => ({
+  queryConcurrentStreams: vi.fn(),
+  queryPlatforms: vi.fn(),
+  queryPlaysByDayOfWeek: vi.fn(),
+  queryPlaysByHourOfDay: vi.fn(),
+  queryPlaysOverTime: vi.fn(),
+  queryQualityBreakdown: vi.fn(),
+}));
+
+import { db } from '../../db/client.js';
+import { publicRoutes } from '../public.js';
+import { generateOpenAPIDocument } from '../public.openapi.js';
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+
+  await app.register(sensible);
+
+  app.decorate('authenticatePublicApi', async () => undefined);
+  app.decorate('redis', {} as never);
+
+  await app.register(publicRoutes, { prefix: '/public' });
+
+  return app;
+}
+
+function createHistoryRow(overrides: Record<string, unknown> = {}) {
+  const serverId = randomUUID();
+  const startedAt = new Date('2026-07-10T10:00:00.000Z');
+  const stoppedAt = new Date('2026-07-10T11:00:00.000Z');
+
+  return {
+    id: randomUUID(),
+    started_at: startedAt,
+    stopped_at: stoppedAt,
+    duration_ms: '3600000',
+    progress_ms: 3_600_000,
+    total_duration_ms: 7_200_000,
+    segment_count: '1',
+    watched: false,
+    state: 'stopped',
+    server_id: serverId,
+    server_name: 'Main Plex',
+    media_type: 'movie',
+    media_title: 'Test Movie',
+    rating_key: '25314',
+    grandparent_title: null,
+    season_number: null,
+    episode_number: null,
+    year: 2010,
+    artist_name: null,
+    album_name: null,
+    track_number: null,
+    disc_number: null,
+    thumb_path: '/library/metadata/25314/thumb',
+    device: 'Apple TV',
+    player_name: 'Plex for Apple TV',
+    product: 'Plex',
+    platform: 'tvOS',
+    is_transcode: false,
+    video_decision: 'directplay',
+    audio_decision: 'directplay',
+    bitrate: 12_000,
+    source_video_codec: 'h264',
+    source_audio_codec: 'aac',
+    source_audio_channels: 6,
+    source_video_width: 1920,
+    source_video_height: 1080,
+    source_video_details: null,
+    source_audio_details: null,
+    stream_video_codec: 'h264',
+    stream_audio_codec: 'aac',
+    stream_video_details: null,
+    stream_audio_details: null,
+    transcode_info: null,
+    subtitle_info: null,
+    imdb_id: 'tt1375666',
+    tmdb_id: 27205,
+    tvdb_id: 12345,
+    grandparent_rating_key: '110397',
+    user_id: randomUUID(),
+    server_username: 'plexuser',
+    user_thumb_url: '/avatar.jpg',
+    user_name: 'Plex User',
+    user_username: 'plexuser',
+    ...overrides,
+  };
+}
+
+describe('Public Routes', () => {
+  let app: FastifyInstance;
+  let mockDb: typeof db;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockDb = db;
+    app = await buildTestApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('GET /public/history', () => {
+    it('returns Reclaimerr-friendly media identifiers and progress fields', async () => {
+      const startedAt = new Date('2026-07-11T10:00:00.000Z');
+      const rowWithoutLibraryMatch = createHistoryRow({
+        id: randomUUID(),
+        started_at: startedAt,
+        stopped_at: null,
+        progress_ms: 1_000,
+        total_duration_ms: null,
+        rating_key: '99999',
+        imdb_id: null,
+        tmdb_id: null,
+        tvdb_id: null,
+        grandparent_rating_key: null,
+      });
+
+      vi.mocked(mockDb.execute)
+        .mockResolvedValueOnce({ rows: [{ count: 2 }] } as never)
+        .mockResolvedValueOnce({
+          rows: [createHistoryRow(), rowWithoutLibraryMatch],
+        } as never);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/public/history',
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const body = response.json();
+      expect(body.meta).toEqual({ total: 2, page: 1, pageSize: 25 });
+
+      expect(body.data[0]).toMatchObject({
+        ratingKey: '25314',
+        grandparentRatingKey: '110397',
+        imdbId: 'tt1375666',
+        tmdbId: 27205,
+        tvdbId: 12345,
+        watchedAt: '2026-07-10T11:00:00.000Z',
+        percentComplete: 50,
+      });
+
+      expect(body.data[1]).toMatchObject({
+        ratingKey: '99999',
+        grandparentRatingKey: null,
+        imdbId: null,
+        tmdbId: null,
+        tvdbId: null,
+        watchedAt: '2026-07-11T10:00:00.000Z',
+        percentComplete: null,
+      });
+    });
+  });
+
+  describe('OpenAPI document', () => {
+    it('documents public history media identifiers', () => {
+      const spec = generateOpenAPIDocument() as {
+        components?: { schemas?: Record<string, { properties?: Record<string, unknown> }> };
+      };
+
+      const sessionHistoryProperties = spec.components?.schemas?.SessionHistory?.properties;
+
+      expect(sessionHistoryProperties).toEqual(
+        expect.objectContaining({
+          ratingKey: expect.any(Object),
+          grandparentRatingKey: expect.any(Object),
+          imdbId: expect.any(Object),
+          tmdbId: expect.any(Object),
+          tvdbId: expect.any(Object),
+          watchedAt: expect.any(Object),
+          percentComplete: expect.any(Object),
+        })
+      );
+    });
+  });
+});

--- a/apps/server/src/routes/public.openapi.ts
+++ b/apps/server/src/routes/public.openapi.ts
@@ -89,13 +89,10 @@ const MediaInfo = z.object({
     .string()
     .nullable()
     .openapi({ description: 'Artist name (music tracks only)', example: 'Pink Floyd' }),
-  albumName: z
-    .string()
-    .nullable()
-    .openapi({
-      description: 'Album name (music tracks only)',
-      example: 'The Dark Side of the Moon',
-    }),
+  albumName: z.string().nullable().openapi({
+    description: 'Album name (music tracks only)',
+    example: 'The Dark Side of the Moon',
+  }),
   trackNumber: z
     .number()
     .int()
@@ -108,6 +105,31 @@ const MediaInfo = z.object({
     .openapi({ description: 'Disc number (music tracks only)', example: 1 }),
   thumbPath: z.string().nullable().openapi({ description: 'Poster path' }),
   posterUrl: z.string().nullable().openapi({ description: 'Proxied poster URL' }),
+});
+
+const PublicHistoryMediaIdentifiers = z.object({
+  ratingKey: z
+    .string()
+    .nullable()
+    .openapi({ description: 'Server-specific media identifier', example: '25314' }),
+  grandparentRatingKey: z
+    .string()
+    .nullable()
+    .openapi({ description: 'Server-specific show/artist identifier for child media' }),
+  imdbId: z
+    .string()
+    .nullable()
+    .openapi({ description: 'IMDB identifier from library sync', example: 'tt1375666' }),
+  tmdbId: z
+    .number()
+    .int()
+    .nullable()
+    .openapi({ description: 'TMDB identifier from library sync', example: 27205 }),
+  tvdbId: z
+    .number()
+    .int()
+    .nullable()
+    .openapi({ description: 'TVDB identifier from library sync', example: 12345 }),
 });
 
 const DeviceInfo = z.object({
@@ -737,6 +759,7 @@ const SessionHistory = z
     ...ServerInfo.shape,
     state: PlaybackStateEnum,
     ...MediaInfo.shape,
+    ...PublicHistoryMediaIdentifiers.shape,
     durationMs: z
       .number()
       .int()
@@ -746,7 +769,18 @@ const SessionHistory = z
     totalDurationMs: z.number().int().nullable().openapi({ description: 'Media length' }),
     startedAt: z.iso.datetime(),
     stoppedAt: z.iso.datetime().nullable(),
+    watchedAt: z.iso
+      .datetime()
+      .nullable()
+      .openapi({ description: 'Stopped time when available, otherwise started time' }),
     watched: z.boolean().openapi({ description: 'True if watched 85%+' }),
+    percentComplete: z
+      .number()
+      .int()
+      .min(0)
+      .max(100)
+      .nullable()
+      .openapi({ description: 'Playback progress percentage derived from progress and duration' }),
     segmentCount: z
       .number()
       .int()

--- a/apps/server/src/routes/public.ts
+++ b/apps/server/src/routes/public.ts
@@ -161,6 +161,15 @@ function paginatedResponse<T>(
   };
 }
 
+function calculatePercentComplete(
+  progressMs: number | null,
+  totalDurationMs: number | null
+): number | null {
+  if (!progressMs || !totalDurationMs || totalDurationMs <= 0) return null;
+  const percent = Math.round((progressMs / totalDurationMs) * 100);
+  return Math.min(100, Math.max(0, percent));
+}
+
 export const publicRoutes: FastifyPluginAsync = async (app) => {
   /**
    * GET /docs - OpenAPI 3.0 specification
@@ -732,6 +741,7 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
         sv.name as server_name,
         s.media_type,
         s.media_title,
+        s.rating_key,
         s.grandparent_title,
         s.season_number,
         s.episode_number,
@@ -762,6 +772,10 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
         s.stream_audio_details,
         s.transcode_info,
         s.subtitle_info,
+        li.imdb_id,
+        li.tmdb_id,
+        li.tvdb_id,
+        li.grandparent_rating_key,
         su.user_id,
         su.username as server_username,
         su.thumb_url as user_thumb_url,
@@ -772,6 +786,7 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
       JOIN server_users su ON su.id = s.server_user_id
       JOIN servers sv ON sv.id = s.server_id
       LEFT JOIN users u ON u.id = su.user_id
+      LEFT JOIN library_items li ON li.server_id = s.server_id AND li.rating_key = s.rating_key
       ORDER BY gs.started_at DESC
     `);
 
@@ -791,6 +806,7 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
         server_name: string;
         media_type: string;
         media_title: string;
+        rating_key: string | null;
         grandparent_title: string | null;
         season_number: number | null;
         episode_number: number | null;
@@ -821,6 +837,10 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
         stream_audio_details: StreamAudioDetails | null;
         transcode_info: TranscodeInfo | null;
         subtitle_info: SubtitleInfo | null;
+        imdb_id: string | null;
+        tmdb_id: number | null;
+        tvdb_id: number | null;
+        grandparent_rating_key: string | null;
         user_id: string;
         server_username: string;
         user_thumb_url: string | null;
@@ -834,6 +854,7 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
       state: row.state,
       mediaType: row.media_type,
       mediaTitle: row.media_title,
+      ratingKey: row.rating_key,
       showTitle: row.grandparent_title,
       seasonNumber: row.season_number,
       episodeNumber: row.episode_number,
@@ -849,8 +870,18 @@ export const publicRoutes: FastifyPluginAsync = async (app) => {
       totalDurationMs: row.total_duration_ms,
       startedAt: row.started_at ? new Date(row.started_at).toISOString() : null,
       stoppedAt: row.stopped_at ? new Date(row.stopped_at).toISOString() : null,
+      watchedAt: row.stopped_at
+        ? new Date(row.stopped_at).toISOString()
+        : row.started_at
+          ? new Date(row.started_at).toISOString()
+          : null,
       watched: row.watched,
+      percentComplete: calculatePercentComplete(row.progress_ms, row.total_duration_ms),
       segmentCount: Number(row.segment_count),
+      grandparentRatingKey: row.grandparent_rating_key,
+      imdbId: row.imdb_id,
+      tmdbId: row.tmdb_id,
+      tvdbId: row.tvdb_id,
       device: row.device,
       player: row.player_name,
       product: row.product,


### PR DESCRIPTION
## Summary

Adds some stable ids for medias so tools like Reclaimerr can utilize them via the API endpoint

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

This takes a similar approach to this but without anything extra. Just targeted identifiers. https://github.com/connorgallopo/Tracearr/pull/696/changes#diff-861c110c5c17197bbe9ec1ad9b81a553769316bc364923fdba18f07baebb4084R23

Closes # https://github.com/connorgallopo/Tracearr/discussions/823#discussioncomment-17624471

## Changes

<!-- What specifically changed? -->

- Now returns session rating keys plus external IDs when there’s a matching library item

## Testing

- [x] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [ ] Tested manually

## AI Disclosure

- Only used to review the code changes

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
