### PR TITLE
Add IPv6 CIDR matching and /64 unique-IP comparison.

### DIFF
--- a/apps/server/src/services/rules.ts
+++ b/apps/server/src/services/rules.ts
@@ -17,6 +17,7 @@ import type {
 } from '@tracearr/shared';
 import { GEOIP_CONFIG, TIME_MS } from '@tracearr/shared';
 import { geoipService } from './geoip.js';
+import { toNetworkKey } from '../utils/ip.js';
 import countries from 'i18n-iso-countries';
 import countriesEn from 'i18n-iso-countries/langs/en.json' with { type: 'json' };
 import { EXCLUDED_MEDIA_TYPES_SET } from '../constants/index.js';
@@ -330,7 +331,11 @@ export class RuleEngine {
     }
 
     let uniqueSources: Set<string>;
-    const uniqueIps = new Set<string>();
+    const ipsByNetwork = new Map<string, string>();
+    const addIp = (ip: string) => {
+      const key = toNetworkKey(ip);
+      if (!ipsByNetwork.has(key)) ipsByNetwork.set(key, ip);
+    };
 
     if (params.groupByDevice) {
       // Group by deviceId - each device counts as 1 source regardless of IP changes
@@ -341,18 +346,19 @@ export class RuleEngine {
           continue;
         }
 
-        const sourceKey = s.deviceId ?? `ip:${s.ipAddress}`;
+        const networkKey = toNetworkKey(s.ipAddress);
+        const sourceKey = s.deviceId ?? `ip:${networkKey}`;
         uniqueSources.add(sourceKey);
-        uniqueIps.add(s.ipAddress);
+        addIp(s.ipAddress);
       }
     } else {
       const allIps = allSessions.map((s) => s.ipAddress);
       const filteredIps = this.filterPrivateIps(allIps, params.excludePrivateIps);
 
       for (const ip of filteredIps) {
-        uniqueIps.add(ip);
+        addIp(ip);
       }
-      uniqueSources = uniqueIps;
+      uniqueSources = new Set(ipsByNetwork.keys());
     }
 
     if (uniqueSources.size > params.maxIps) {
@@ -363,7 +369,7 @@ export class RuleEngine {
           uniqueIpCount: uniqueSources.size,
           maxAllowedIps: params.maxIps,
           windowHours: params.windowHours,
-          ips: Array.from(uniqueIps),
+          ips: Array.from(ipsByNetwork.values()),
           ...(params.groupByDevice && { groupedByDevice: true }),
         },
       };

--- a/apps/server/src/services/rules/__tests__/evaluators.test.ts
+++ b/apps/server/src/services/rules/__tests__/evaluators.test.ts
@@ -481,6 +481,48 @@ describe('Session Behavior Evaluators', () => {
       expect(result3.actual).toBe(2);
     });
 
+    it('treats IPv6 addresses in the same /64 as one IP when exclude_same_ip is true', async () => {
+      const session1 = createMockSession({
+        id: 's1',
+        serverUserId: 'user-1',
+        deviceId: 'device-1',
+        ipAddress: '2001:db8:abcd:7800:58f:b385:9778:7ab6',
+      });
+      const session2 = createMockSession({
+        id: 's2',
+        serverUserId: 'user-1',
+        deviceId: 'device-2',
+        ipAddress: '2001:db8:abcd:7800:c969:3c04:cdd4:13bd', // Same /64 as session1
+      });
+      const session3 = createMockSession({
+        id: 's3',
+        serverUserId: 'user-1',
+        deviceId: 'device-3',
+        ipAddress: '2001:db8:abcd:7801:aaaa:bbbb:cccc:dddd', // Different /64
+      });
+
+      const ctx = createTestContext({
+        session: session1,
+        serverUser: createMockServerUser({ id: 'user-1' }),
+        activeSessions: [session1, session2, session3],
+      });
+
+      const evaluator = evaluatorRegistry.concurrent_streams;
+
+      // With exclude_same_ip: session1+session2 count as one IP, session3 is different → 2
+      const result = await evaluator(
+        ctx,
+        createCondition({
+          field: 'concurrent_streams',
+          operator: 'eq',
+          value: 2,
+          params: { exclude_same_ip: true },
+        })
+      );
+      expect(result.matched).toBe(true);
+      expect(result.actual).toBe(2);
+    });
+
     it('only counts sessions from listed device types when count_device_types is set', async () => {
       const tvSession = createMockSession({
         id: 's1',
@@ -1066,6 +1108,45 @@ describe('Session Behavior Evaluators', () => {
               field: 'unique_ips_in_window',
               operator: 'eq',
               value: 1,
+            })
+          )
+        )
+      ).toBe(true);
+    });
+
+    it('counts IPv6 addresses in the same /64 as one unique IP', () => {
+      const now = new Date();
+      const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+
+      const session1 = createMockSession({
+        id: 's1',
+        serverUserId: 'user-1',
+        startedAt: now,
+        ipAddress: '2001:db8:abcd:7800:58f:b385:9778:7ab6',
+      });
+      const session2 = createMockSession({
+        id: 's2',
+        serverUserId: 'user-1',
+        startedAt: oneHourAgo,
+        ipAddress: '2001:db8:abcd:7800:c969:3c04:cdd4:13bd',
+      });
+
+      const ctx = createTestContext({
+        session: session1,
+        serverUser: createMockServerUser({ id: 'user-1' }),
+        recentSessions: [session1, session2],
+      });
+
+      const evaluator = evaluatorRegistry.unique_ips_in_window;
+      expect(
+        matched(
+          evaluator(
+            ctx,
+            createCondition({
+              field: 'unique_ips_in_window',
+              operator: 'eq',
+              value: 1,
+              params: { window_hours: 24 },
             })
           )
         )
@@ -2236,6 +2317,51 @@ describe('Network/Location Evaluators', () => {
           evaluator(
             ctx,
             createCondition({ field: 'ip_in_range', operator: 'in', value: ['0.0.0.0/0'] })
+          )
+        )
+      ).toBe(false);
+    });
+
+    it('works with IPv6 CIDR ranges', () => {
+      const session = createMockSession({
+        ipAddress: '2001:db8:abcd:7800:58f:b385:9778:7ab6',
+      });
+      const ctx = createTestContext({ session });
+
+      const evaluator = evaluatorRegistry.ip_in_range;
+      expect(
+        matched(
+          evaluator(
+            ctx,
+            createCondition({
+              field: 'ip_in_range',
+              operator: 'eq',
+              value: '2001:db8:abcd:7800::/64',
+            })
+          )
+        )
+      ).toBe(true);
+      expect(
+        matched(
+          evaluator(
+            ctx,
+            createCondition({
+              field: 'ip_in_range',
+              operator: 'eq',
+              value: '2001:db8:abcd:7801::/64',
+            })
+          )
+        )
+      ).toBe(false);
+      expect(
+        matched(
+          evaluator(
+            ctx,
+            createCondition({
+              field: 'ip_in_range',
+              operator: 'neq',
+              value: '2001:db8:abcd:7800::/64',
+            })
           )
         )
       ).toBe(false);

--- a/apps/server/src/services/rules/evaluators/index.ts
+++ b/apps/server/src/services/rules/evaluators/index.ts
@@ -7,6 +7,7 @@ import type {
   TranscodingConditionValue,
   VideoResolution,
 } from '@tracearr/shared';
+import { isIpInCidr, toNetworkKey } from '../../../utils/ip.js';
 import { normalizeResolution } from '../../../utils/resolutionNormalizer.js';
 import { geoipService } from '../../geoip.js';
 import { compare } from '../comparisons.js';
@@ -218,10 +219,12 @@ const evaluateConcurrentStreams: ConditionEvaluator = (
     );
   }
 
-  // When exclude_same_ip is true, only count triggering session + sessions from different IPs.
+  // When exclude_same_ip is true, only count triggering session + sessions from different IPs
+  // (IPv6 compared by /64 network key).
   if (excludeSameIp) {
+    const sessionKey = toNetworkKey(session.ipAddress);
     userActiveSessions = userActiveSessions.filter(
-      (s) => s.id === session.id || s.ipAddress !== session.ipAddress
+      (s) => s.id === session.id || toNetworkKey(s.ipAddress) !== sessionKey
     );
   }
 
@@ -391,18 +394,21 @@ const evaluateUniqueIpsInWindow: ConditionEvaluator = (
     (s) => isIdentitySession(s) && new Date(s.startedAt) >= cutoff
   );
 
-  // Include the current session
-  const allIps = new Set<string>();
-  allIps.add(session.ipAddress);
-
+  // Include the current session. Count by network key; keep original IPs for details.
+  const ipsByNetwork = new Map<string, string>();
+  const addIp = (ip: string) => {
+    const key = toNetworkKey(ip);
+    if (!ipsByNetwork.has(key)) ipsByNetwork.set(key, ip);
+  };
+  addIp(session.ipAddress);
   for (const s of sessionsInWindow) {
-    allIps.add(s.ipAddress);
+    addIp(s.ipAddress);
   }
 
   return {
-    matched: compare(allIps.size, condition.operator, condition.value),
-    actual: allIps.size,
-    details: { ips: Array.from(allIps), windowHours },
+    matched: compare(ipsByNetwork.size, condition.operator, condition.value),
+    actual: ipsByNetwork.size,
+    details: { ips: Array.from(ipsByNetwork.values()), windowHours },
   };
 };
 
@@ -799,45 +805,6 @@ const evaluateCountry: ConditionEvaluator = (
     actual: country,
   };
 };
-
-/**
- * Parse an IPv4 address into a 32-bit number.
- */
-function ipv4ToNumber(ip: string): number | null {
-  const parts = ip.split('.');
-  if (parts.length !== 4) return null;
-
-  let result = 0;
-  for (const part of parts) {
-    const num = parseInt(part, 10);
-    if (isNaN(num) || num < 0 || num > 255) return null;
-    result = (result << 8) + num;
-  }
-  return result >>> 0; // Convert to unsigned 32-bit
-}
-
-/**
- * Check if an IP address is within a CIDR range.
- * Supports IPv4 only. Returns false for IPv6 or invalid input.
- */
-function isIpInCidr(ip: string, cidr: string): boolean {
-  const ipNum = ipv4ToNumber(ip);
-  if (ipNum === null) return false;
-
-  const [rangeIp, prefixStr] = cidr.split('/');
-  if (!rangeIp || !prefixStr) return false;
-
-  const rangeNum = ipv4ToNumber(rangeIp);
-  if (rangeNum === null) return false;
-
-  const prefix = parseInt(prefixStr, 10);
-  if (isNaN(prefix) || prefix < 0 || prefix > 32) return false;
-
-  // Create mask: for prefix=24, mask = 0xFFFFFF00
-  const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
-
-  return (ipNum & mask) === (rangeNum & mask);
-}
 
 const evaluateIpInRange: ConditionEvaluator = (
   context: EvaluationContext,

--- a/apps/server/src/utils/__tests__/ip.test.ts
+++ b/apps/server/src/utils/__tests__/ip.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { isIpInCidr, toNetworkKey } from '../ip.js';
+
+describe('isIpInCidr', () => {
+  it('matches IPv4 addresses within a CIDR range', () => {
+    expect(isIpInCidr('192.168.1.100', '192.168.1.0/24')).toBe(true);
+    expect(isIpInCidr('192.168.2.1', '192.168.1.0/24')).toBe(false);
+    expect(isIpInCidr('10.0.5.25', '10.0.0.0/8')).toBe(true);
+  });
+
+  it('matches exact IPv4 with /32', () => {
+    expect(isIpInCidr('192.168.1.1', '192.168.1.1/32')).toBe(true);
+    expect(isIpInCidr('192.168.1.2', '192.168.1.1/32')).toBe(false);
+  });
+
+  it('matches IPv6 addresses within a /64 CIDR', () => {
+    expect(isIpInCidr('2001:db8:abcd:7800:58f:b385:9778:7ab6', '2001:db8:abcd:7800::/64')).toBe(
+      true
+    );
+    expect(isIpInCidr('2001:db8:abcd:7800:c969:3c04:cdd4:13bd', '2001:db8:abcd:7800::/64')).toBe(
+      true
+    );
+    expect(isIpInCidr('2001:db8:abcd:7801:58f:b385:9778:7ab6', '2001:db8:abcd:7800::/64')).toBe(
+      false
+    );
+  });
+
+  it('matches compressed and expanded IPv6 forms', () => {
+    expect(isIpInCidr('2001:db8::1', '2001:db8::/32')).toBe(true);
+    expect(isIpInCidr('2001:0db8:0000:0000:0000:0000:0000:0001', '2001:db8::/32')).toBe(true);
+  });
+
+  it('unmaps IPv4-mapped addresses before matching a v4 CIDR', () => {
+    expect(isIpInCidr('::ffff:192.168.1.100', '192.168.1.0/24')).toBe(true);
+    expect(isIpInCidr('::ffff:192.168.2.1', '192.168.1.0/24')).toBe(false);
+    expect(isIpInCidr('::ffff:10.0.5.25', '10.0.0.0/8')).toBe(true);
+    // Hex form: ::ffff:c0a8:164 === 192.168.1.100
+    expect(isIpInCidr('::ffff:c0a8:164', '192.168.1.0/24')).toBe(true);
+    expect(isIpInCidr('::ffff:c0a8:201', '192.168.1.0/24')).toBe(false);
+  });
+
+  it('rejects mismatched address families', () => {
+    expect(isIpInCidr('192.168.1.1', '2001:db8::/32')).toBe(false);
+    expect(isIpInCidr('2001:db8::1', '192.168.0.0/16')).toBe(false);
+  });
+
+  it('rejects invalid input', () => {
+    expect(isIpInCidr('', '192.168.0.0/16')).toBe(false);
+    expect(isIpInCidr('192.168.1.1', 'not-a-cidr')).toBe(false);
+    expect(isIpInCidr('192.168.1.1', '192.168.0.0/99')).toBe(false);
+    expect(isIpInCidr('2001:db8::1', '2001:db8::/129')).toBe(false);
+  });
+});
+
+describe('toNetworkKey', () => {
+  it('leaves IPv4 addresses unchanged', () => {
+    expect(toNetworkKey('192.168.1.100')).toBe('192.168.1.100');
+    expect(toNetworkKey('8.8.8.8')).toBe('8.8.8.8');
+  });
+
+  it('collapses IPv6 addresses in the same /64 to one key', () => {
+    const a = toNetworkKey('2001:db8:abcd:7800:58f:b385:9778:7ab6');
+    const b = toNetworkKey('2001:db8:abcd:7800:c969:3c04:cdd4:13bd');
+    expect(a).toBe(b);
+    expect(a).toBe('2001:db8:abcd:7800:0:0:0:0');
+  });
+
+  it('treats different /64 networks as different keys', () => {
+    const a = toNetworkKey('2001:db8:abcd:7800:58f:b385:9778:7ab6');
+    const b = toNetworkKey('2001:db8:abcd:7801:58f:b385:9778:7ab6');
+    expect(a).not.toBe(b);
+  });
+
+  it('normalizes compressed IPv6 before masking', () => {
+    expect(toNetworkKey('2001:db8::1')).toBe(toNetworkKey('2001:db8:0:0:1:2:3:4'));
+  });
+
+  it('unmaps IPv4-mapped addresses so they compare as IPv4', () => {
+    expect(toNetworkKey('::ffff:1.2.3.4')).toBe('1.2.3.4');
+    expect(toNetworkKey('::ffff:8.8.8.8')).not.toBe(toNetworkKey('::ffff:1.1.1.1'));
+    expect(toNetworkKey('::ffff:c0a8:164')).toBe('192.168.1.100');
+    expect(toNetworkKey('::ffff:c0a8:164')).toBe(toNetworkKey('::ffff:192.168.1.100'));
+  });
+});

--- a/apps/server/src/utils/ip.ts
+++ b/apps/server/src/utils/ip.ts
@@ -1,0 +1,115 @@
+/**
+ * IP helpers for CIDR matching and IPv6 unique-IP comparison.
+ */
+
+import { BlockList, isIP } from 'node:net';
+
+/**
+ * Unmap IPv4-mapped IPv6 so dual-stack clients match v4 CIDR rules and
+ * count as v4 unique IPs. Handles dotted (::ffff:1.2.3.4) and hex
+ * (::ffff:c0a8:164) forms.
+ */
+function unmapIpv4Mapped(ip: string): string {
+  const lower = ip.toLowerCase();
+
+  // ::ffff:192.168.1.100
+  if (lower.startsWith('::ffff:')) {
+    const rest = ip.slice(7);
+    if (isIP(rest) === 4) return rest;
+  }
+
+  // ::ffff:c0a8:164 → 192.168.1.100
+  const hex = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(lower);
+  if (hex) {
+    const hi = parseInt(hex[1]!, 16);
+    const lo = parseInt(hex[2]!, 16);
+    return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+  }
+
+  return ip;
+}
+
+/** True if ip falls within cidr. Supports IPv4 and IPv6. */
+export function isIpInCidr(ip: string, cidr: string): boolean {
+  if (!ip || !cidr) return false;
+
+  const normalized = unmapIpv4Mapped(ip);
+
+  const slash = cidr.lastIndexOf('/');
+  if (slash <= 0 || slash === cidr.length - 1) return false;
+
+  const rangeIp = cidr.slice(0, slash);
+  const prefix = Number(cidr.slice(slash + 1));
+
+  const ipFamily = isIP(normalized);
+  const rangeFamily = isIP(rangeIp);
+  if (!ipFamily || !rangeFamily || ipFamily !== rangeFamily) return false;
+
+  const maxPrefix = ipFamily === 4 ? 32 : 128;
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > maxPrefix) return false;
+
+  try {
+    const list = new BlockList();
+    const type = ipFamily === 4 ? 'ipv4' : 'ipv6';
+    list.addSubnet(rangeIp, prefix, type);
+    return list.check(normalized, type);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Comparison key for unique-IP rules: IPv4 unchanged; IPv6 masked to /64.
+ */
+export function toNetworkKey(ip: string): string {
+  if (!ip) return ip;
+
+  const normalized = unmapIpv4Mapped(ip);
+  const family = isIP(normalized);
+  if (family === 4) return normalized;
+  if (family !== 6) return ip;
+
+  const bytes = parseIpv6ToBytes(normalized);
+  if (!bytes) return ip;
+
+  // /64: keep the network prefix, zero the interface identifier
+  bytes.fill(0, 8);
+  return formatIpv6Bytes(bytes);
+}
+
+function parseIpv6ToBytes(ip: string): Uint8Array | null {
+  const addr = ip.toLowerCase().split('%')[0] ?? '';
+  if (!addr) return null;
+
+  let parts: string[];
+  if (addr.includes('::')) {
+    const [left = '', right = ''] = addr.split('::');
+    const leftParts = left ? left.split(':') : [];
+    const rightParts = right ? right.split(':') : [];
+    const missing = 8 - leftParts.length - rightParts.length;
+    if (missing < 0) return null;
+    parts = [...leftParts, ...Array(missing).fill('0'), ...rightParts];
+  } else {
+    parts = addr.split(':');
+  }
+
+  if (parts.length !== 8) return null;
+
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 8; i++) {
+    const hextet = parts[i]!;
+    if (!/^[0-9a-f]{1,4}$/.test(hextet)) return null;
+    const value = parseInt(hextet, 16);
+    bytes[i * 2] = (value >> 8) & 0xff;
+    bytes[i * 2 + 1] = value & 0xff;
+  }
+  return bytes;
+}
+
+function formatIpv6Bytes(bytes: Uint8Array): string {
+  const hextets: string[] = [];
+  for (let i = 0; i < 16; i += 2) {
+    hextets.push(((bytes[i]! << 8) | bytes[i + 1]!).toString(16));
+  }
+  return hextets.join(':');
+}

--- a/apps/web/src/lib/rules/conditionFields.ts
+++ b/apps/web/src/lib/rules/conditionFields.ts
@@ -353,11 +353,11 @@ export const FIELD_DEFINITIONS: Record<ConditionField, FieldDefinition> = {
   ip_in_range: {
     field: 'ip_in_range',
     label: 'IP Range',
-    description: 'IP address in CIDR range',
+    description: 'IP address in CIDR range (IPv4 or IPv6)',
     category: 'network_location',
     operators: EQUALITY_OPERATORS,
     valueType: 'cidr',
-    placeholder: 'e.g., 192.168.1.0/24',
+    placeholder: 'e.g., 192.168.1.0/24 or 2001:db8:abcd:7800::/64',
   },
 
   // Scope


### PR DESCRIPTION
## Summary

This implements the Part 1 approach discussed in #934.

It adds IPv6 support to **IP Range** rules and updates the Unique IP comparisons used by **Unique IPs**, **Unique IPs in Window**, and the **Concurrent Streams** "same IP" exclusion to compare IPv6 addresses by `/64`. Existing IPv4 behaviour is unchanged.

As discussed I've kept the scope narrow. No configurable IPv6 prefixes, LAN household grouping, or any schema/UI/template changes.

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation
* [ ] Refactor
* [ ] Breaking change

## Related issue

Closes #934

## What's included

* Added `isIpInCidr` using Node's `BlockList` for IPv4 and IPv6 CIDR matching.
* Normalised IPv4-mapped IPv6 addresses (`::ffff:x.x.x.x` and the hexadecimal form, rare but good idea to cover) before CIDR matching and Unique IP comparisons.
* Added `toNetworkKey`:
  * IPv4 is compared as-is.
  * IPv6 is normalised to a hardcoded `/64`.
* Updated:
  * Unique IPs
  * Unique IPs in Window
  * Concurrent Streams `exclude_same_ip`
  * Legacy device velocity unique-IP counting
* Updated the IP Range placeholder to mention IPv6 CIDRs.
* Added unit tests for the new helpers and rule evaluators.

## Testing

* [x] Added/updated unit tests
* [x] Ran `pnpm typecheck`
* [x] Ran `pnpm lint`
* [x] Ran `pnpm test:unit`
* [x] Pre-push hooks passed
* [x] Manually tested against an IPv6-enabled server