### PR TITLE
Show the accounts and device count behind a map marker

### DIFF
--- a/apps/web/src/components/map/StreamMap.test.tsx
+++ b/apps/web/src/components/map/StreamMap.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { LocationStats } from '@tracearr/shared';
+
+// Leaflet needs a real map container, and none of it is involved in the popup
+// body under test, so the map primitives are stubbed at import time.
+vi.mock('react-leaflet', () => ({
+  MapContainer: () => null,
+  TileLayer: () => null,
+  useMap: () => ({ on: vi.fn(), off: vi.fn(), fitBounds: vi.fn() }),
+  ZoomControl: () => null,
+  CircleMarker: () => null,
+  Popup: () => null,
+}));
+
+vi.mock('react-leaflet-heatmap-layer-v3', () => ({
+  HeatmapLayer: () => null,
+}));
+
+import { LocationPopupContent } from './StreamMap';
+
+function makeLocation(overrides: Partial<LocationStats> = {}): LocationStats {
+  return {
+    city: 'Porto Alegre',
+    region: 'Rio Grande do Sul',
+    country: 'BR',
+    lat: -30.1188,
+    lon: -51.168,
+    count: 3,
+    ...overrides,
+  };
+}
+
+describe('LocationPopupContent', () => {
+  it('lists every account behind a shared marker', () => {
+    // GeoIP resolves every address in a city to the same coordinates, so two
+    // different people collapse into one marker. Both have to be readable.
+    render(
+      <LocationPopupContent
+        location={makeLocation({
+          users: [
+            { id: 'u1', username: 'conradir', thumbUrl: null },
+            { id: 'u2', username: 'bruxao', thumbUrl: null },
+          ],
+          deviceCount: 2,
+        })}
+      />
+    );
+
+    expect(screen.getByText('conradir')).toBeInTheDocument();
+    expect(screen.getByText('bruxao')).toBeInTheDocument();
+  });
+
+  it('reports the unique device count next to the stream count', () => {
+    render(
+      <LocationPopupContent
+        location={makeLocation({
+          count: 3,
+          users: [{ id: 'u1', username: 'conradir', thumbUrl: null }],
+          deviceCount: 2,
+        })}
+      />
+    );
+
+    expect(screen.getByText(/3 streams from 2 devices/)).toBeInTheDocument();
+  });
+
+  it('singularises a marker holding one stream on one device', () => {
+    render(
+      <LocationPopupContent
+        location={makeLocation({
+          count: 1,
+          users: [{ id: 'u1', username: 'conradir', thumbUrl: null }],
+          deviceCount: 1,
+        })}
+      />
+    );
+
+    expect(screen.getByText(/1 stream from 1 device/)).toBeInTheDocument();
+  });
+
+  it('omits the device count when the API does not send one', () => {
+    // /stats/locations leaves users and deviceCount out while a single account
+    // is selected, since the answer would just be the account already filtered on.
+    render(<LocationPopupContent location={makeLocation({ count: 3 })} />);
+
+    expect(screen.getByText(/3 streams/)).toBeInTheDocument();
+    expect(screen.queryByText(/device/)).not.toBeInTheDocument();
+  });
+
+  it('falls back to Unknown when the country is missing', () => {
+    render(<LocationPopupContent location={makeLocation({ city: null, country: null })} />);
+
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+
+  it('still renders the per-server breakdown', () => {
+    render(
+      <LocationPopupContent
+        location={makeLocation({ users: [{ id: 'u1', username: 'conradir', thumbUrl: null }] })}
+        serverBreakdown={[
+          { serverId: 's1', count: 2 },
+          { serverId: 's2', count: 1 },
+        ]}
+        serverNameMap={{ s1: 'Main', s2: 'Backup' }}
+      />
+    );
+
+    expect(screen.getByText('Main')).toBeInTheDocument();
+    expect(screen.getByText('Backup')).toBeInTheDocument();
+    // The account list and the server list are separate blocks.
+    expect(screen.getByText('conradir')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/map/StreamMap.tsx
+++ b/apps/web/src/components/map/StreamMap.tsx
@@ -126,6 +126,71 @@ interface CircleMarkersLayerProps {
   isMultiServer?: boolean;
 }
 
+interface LocationPopupContentProps {
+  location: LocationStats;
+  serverBreakdown?: { serverId: string; count: number }[];
+  serverNameMap?: Record<string, string>;
+}
+
+/**
+ * Body of a location marker popup.
+ *
+ * One marker can cover several people, because GeoIP resolves every address in
+ * a city to the same coordinates. /stats/locations already returns the accounts
+ * and the unique device count behind each marker, so both are listed here to
+ * make a shared location readable.
+ *
+ * Exported for tests: Leaflet mounts popup children only once the popup opens,
+ * which a jsdom render cannot drive.
+ */
+export function LocationPopupContent({
+  location,
+  serverBreakdown,
+  serverNameMap,
+}: LocationPopupContentProps) {
+  const users = location.users ?? [];
+  const deviceCount = location.deviceCount ?? 0;
+
+  return (
+    <div className="text-sm">
+      <div className="font-semibold">
+        {location.city ? `${location.city}, ` : ''}
+        {location.country || 'Unknown'}
+      </div>
+      <div className="text-muted-foreground">
+        {location.count.toLocaleString()} stream{location.count !== 1 ? 's' : ''}
+        {deviceCount > 0 && (
+          <>
+            {' from '}
+            {deviceCount.toLocaleString()} device{deviceCount !== 1 ? 's' : ''}
+          </>
+        )}
+      </div>
+      {users.length > 0 && (
+        <div className="mt-1.5 space-y-0.5 border-t pt-1.5">
+          {users.map((user) => (
+            <div key={user.id} className="text-muted-foreground">
+              {user.username}
+            </div>
+          ))}
+        </div>
+      )}
+      {serverBreakdown && serverNameMap && (
+        <div className="mt-1.5 space-y-0.5 border-t pt-1.5">
+          {serverBreakdown.map((entry) => (
+            <div key={entry.serverId} className="flex items-center justify-between gap-3">
+              <span className="text-muted-foreground">
+                {serverNameMap[entry.serverId] ?? entry.serverId}
+              </span>
+              <span className="tabular-nums">{entry.count.toLocaleString()}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // Circle markers layer component
 function CircleMarkersLayer({
   locations,
@@ -186,30 +251,11 @@ function CircleMarkersLayer({
               }}
             >
               <Popup>
-                <div className="text-sm">
-                  <div className="font-semibold">
-                    {location.city ? `${location.city}, ` : ''}
-                    {location.country || 'Unknown'}
-                  </div>
-                  <div className="text-muted-foreground">
-                    {location.count.toLocaleString()} stream{location.count !== 1 ? 's' : ''}
-                  </div>
-                  {serverBreakdown && serverNameMap && (
-                    <div className="mt-1.5 space-y-0.5 border-t pt-1.5">
-                      {serverBreakdown.map((entry) => (
-                        <div
-                          key={entry.serverId}
-                          className="flex items-center justify-between gap-3"
-                        >
-                          <span className="text-muted-foreground">
-                            {serverNameMap[entry.serverId] ?? entry.serverId}
-                          </span>
-                          <span className="tabular-nums">{entry.count.toLocaleString()}</span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
+                <LocationPopupContent
+                  location={location}
+                  serverBreakdown={serverBreakdown}
+                  serverNameMap={serverNameMap}
+                />
               </Popup>
             </CircleMarker>
           );


### PR DESCRIPTION
## Summary

When several people share a location, the map draws one marker and the popup only says how many streams it holds. There is no way to tell that more than one person is behind it.

`/stats/locations` already answers this. `location_detail` computes `device_count` and aggregates `user_info`, the route maps them onto `users` and `deviceCount`, and `LocationStats` declares both. Nothing rendered them, so the data was being computed and sent on every request and then dropped on the floor.

This renders them in the popup. No API or schema change, no new query.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

Discussed in #439, open since December and asking for exactly this: a way to see
who is behind a marker instead of just how many streams it holds. @mrjohnpoz
describes the same situation I hit, seeing streams from a location and having no
way to tell which users they were.

I opened #972 before I found that discussion, and @connorgallopo was right that
this is a design question rather than a bug, so the discussion is the correct
home for it. Relates to #439.

This PR covers the popup half of that request. The full session list asked for
in #439 is a larger step and I did not want to assume the design.

## Changes

- Extract the popup body from `CircleMarkersLayer` into an exported `LocationPopupContent`. Leaflet mounts popup children only when the popup opens, so this is also what makes the content reachable from a jsdom test.
- List `location.users` in the popup, one account per line, in a block above the existing per-server breakdown.
- Append the unique device count to the stream line, so a shared marker reads `3 streams from 2 devices`.
- Add `StreamMap.test.tsx` covering the shared-marker case, the singular and plural wording, the filtered case where the API omits both fields, the missing-country fallback, and the existing server breakdown.

Two things I deliberately left alone:

- The account list is capped at 5 by the existing `.slice(0, 5)` in the route, and the response carries no total, so the popup cannot say "and 2 more". Lifting that would mean changing the endpoint, which felt out of scope for a bug fix. Happy to follow up if you want it.
- `StreamMap` has no `useTranslation` today and its existing strings are hardcoded English. I matched that rather than half-translating the component. Glad to wire up i18n here if you would prefer that instead.

## Screenshots

Not an image, since the change is the text inside the Leaflet popup. What the
marker with two viewers renders, before and after:

```
before                  after
------                  -----
Porto Alegre, BR        Porto Alegre, BR
3 streams               3 streams from 2 devices
                        ---------------------------
                        conradir
                        bruxao
```

Happy to attach a real screenshot if you would like one.

## Testing

- [x] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Full web suite passes, 463 tests across 58 files, including the 6 added here. `pnpm typecheck` is clean and `eslint` reports no new warnings for the touched files (the 3 it flags in `StreamMap.tsx` are the pre-existing `window.matchMedia` call, which only moved line).

I checked that the new tests actually catch the bug rather than just passing: with the account list removed from the component, `lists every account behind a shared marker` and `still renders the per-server breakdown` both fail on the missing username.

Manually verified against my own install, where two accounts on different networks in the same city share one marker.

## AI Disclosure

- [x] AI tools were used significantly in writing this code

Claude helped trace the data path from the SQL in `locations.ts` through to the popup, and drafted the component extraction and the tests. I reviewed the diff, ran the checks above, and confirmed the failing-test check myself.

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed, and I can explain every part of this diff
- [x] For features: discussed with a code owner first (linked above)
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
