### PR TITLE
Fix duplicate owner account minted by Plex session user id alias

### DIFF
--- a/apps/server/src/jobs/__tests__/sseProcessorConcurrency.test.ts
+++ b/apps/server/src/jobs/__tests__/sseProcessorConcurrency.test.ts
@@ -97,6 +97,7 @@ vi.mock('../../services/mediaServer/index.js', () => ({
 vi.mock('../../services/plexGeoip.js', () => ({ lookupGeoIP: mockLookupGeoIP }));
 vi.mock('../../services/userService.js', () => ({
   getIdentityServerUserIds: mockGetIdentityServerUserIds,
+  canonicalPlexExternalUserId: vi.fn(async (id: string) => id),
 }));
 vi.mock('../../routes/settings.js', () => ({
   getGeoIPSettings: vi.fn().mockResolvedValue({ usePlexGeoip: false }),

--- a/apps/server/src/jobs/__tests__/sseProcessorPendingSessions.test.ts
+++ b/apps/server/src/jobs/__tests__/sseProcessorPendingSessions.test.ts
@@ -128,6 +128,7 @@ vi.mock('../../routes/settings.js', () => ({
 
 vi.mock('../../services/userService.js', () => ({
   getIdentityServerUserIds: mockGetIdentityServerUserIds,
+  canonicalPlexExternalUserId: vi.fn(async (id: string) => id),
 }));
 
 vi.mock('../poller/index.js', () => ({

--- a/apps/server/src/jobs/__tests__/sseProcessorUpdateGuard.test.ts
+++ b/apps/server/src/jobs/__tests__/sseProcessorUpdateGuard.test.ts
@@ -67,6 +67,7 @@ vi.mock('../../services/mediaServer/index.js', () => ({
 vi.mock('../../services/plexGeoip.js', () => ({ lookupGeoIP: vi.fn() }));
 vi.mock('../../services/userService.js', () => ({
   getIdentityServerUserIds: vi.fn().mockResolvedValue(['server-user-1']),
+  canonicalPlexExternalUserId: vi.fn(async (id: string) => id),
 }));
 vi.mock('../../routes/settings.js', () => ({
   getGeoIPSettings: vi.fn().mockResolvedValue({ usePlexGeoip: false }),

--- a/apps/server/src/jobs/poller/processor.ts
+++ b/apps/server/src/jobs/poller/processor.ts
@@ -26,6 +26,7 @@ import type { CacheService, PubSubService } from '../../services/cache.js';
 import { type GeoLocation } from '../../services/geoip.js';
 import { createMediaServerClient } from '../../services/mediaServer/index.js';
 import { lookupGeoIP } from '../../services/plexGeoip.js';
+import { canonicalPlexExternalUserId } from '../../services/userService.js';
 import { registerService, unregisterService } from '../../services/serviceTracker.js';
 import { getWatchedThreshold } from '../../services/settings.js';
 import { sseManager } from '../../services/sseManager.js';
@@ -768,6 +769,16 @@ async function processServerSessions(
     sseManager.nudgeReconnect(server.id);
 
     const processedSessions = mediaSessions.map((s) => mapMediaSession(s, server.type));
+
+    // Plex aliases the server owner as user id "1" in session payloads;
+    // resolve it to their plex.tv account id so the owner's plays land on
+    // their real server user instead of minting a duplicate (see
+    // canonicalPlexExternalUserId).
+    if (server.type === 'plex') {
+      for (const processed of processedSessions) {
+        processed.externalUserId = await canonicalPlexExternalUserId(processed.externalUserId);
+      }
+    }
 
     // OPTIMIZATION: Early return if no active sessions from media server
     if (processedSessions.length === 0) {

--- a/apps/server/src/jobs/sseProcessor.ts
+++ b/apps/server/src/jobs/sseProcessor.ts
@@ -28,7 +28,7 @@ import { lookupGeoIP } from '../services/plexGeoip.js';
 import { registerService, unregisterService } from '../services/serviceTracker.js';
 import { getWatchedThreshold } from '../services/settings.js';
 import { sseManager } from '../services/sseManager.js';
-import { getIdentityServerUserIds } from '../services/userService.js';
+import { canonicalPlexExternalUserId, getIdentityServerUserIds } from '../services/userService.js';
 import { createLogger } from '../utils/logger.js';
 import { enqueueNotification } from './notificationQueue.js';
 import {
@@ -1028,6 +1028,11 @@ async function fetchFullSession(
     }
 
     const session = mapMediaSession(targetSession, server.type);
+    // Plex aliases the server owner as user id "1" in session payloads;
+    // resolve it to their plex.tv account id (see canonicalPlexExternalUserId).
+    if (server.type === 'plex') {
+      session.externalUserId = await canonicalPlexExternalUserId(session.externalUserId);
+    }
     // Stamp identity like the poller does or SSE session rows insert with null media columns
     if (session.ratingKey) {
       const identityMap = await batchGetLibraryItemIdentity(server.id, [session.ratingKey]);

--- a/apps/server/src/services/__tests__/userService.test.ts
+++ b/apps/server/src/services/__tests__/userService.test.ts
@@ -5,7 +5,7 @@
  * Uses mocked database to test business logic in isolation.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 
 // Mock the database
@@ -27,6 +27,7 @@ import {
   getUserByPlexAccountId,
   getUserByUsername,
   getOwnerUser,
+  canonicalPlexExternalUserId,
   getServerUserWithDetails,
   getUserWithStats,
   createOwnerUser,
@@ -208,6 +209,65 @@ describe('getOwnerUser', () => {
     const result = await getOwnerUser();
 
     expect(result).toBeNull();
+  });
+});
+
+describe('canonicalPlexExternalUserId', () => {
+  // The owner lookup result is cached at module level for 60s; use fake
+  // timers on a clock that advances past the TTL before every test so each
+  // scenario starts from a fresh lookup regardless of what ran before it.
+  let clock = Date.now();
+
+  beforeEach(() => {
+    clock += 120_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(clock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('passes through ids other than the local admin alias without touching the db', async () => {
+    const result = await canonicalPlexExternalUserId('ext-123');
+
+    expect(result).toBe('ext-123');
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('resolves the "1" alias to the owner plex.tv account id', async () => {
+    mockSelectChain([createMockUser({ role: 'owner', plexAccountId: 'plex-12345' })]);
+
+    const result = await canonicalPlexExternalUserId('1');
+
+    expect(result).toBe('plex-12345');
+  });
+
+  it('caches the owner lookup between calls within the TTL', async () => {
+    mockSelectChain([createMockUser({ role: 'owner', plexAccountId: 'plex-12345' })]);
+
+    await canonicalPlexExternalUserId('1');
+    await canonicalPlexExternalUserId('1');
+
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the raw alias when the owner has no linked plex account', async () => {
+    mockSelectChain([createMockUser({ role: 'owner', plexAccountId: null })]);
+
+    const result = await canonicalPlexExternalUserId('1');
+
+    expect(result).toBe('1');
+  });
+
+  it('returns the raw alias when the owner lookup fails', async () => {
+    vi.mocked(db.select).mockImplementation(() => {
+      throw new Error('db down');
+    });
+
+    const result = await canonicalPlexExternalUserId('1');
+
+    expect(result).toBe('1');
   });
 });
 

--- a/apps/server/src/services/userService.ts
+++ b/apps/server/src/services/userService.ts
@@ -140,6 +140,42 @@ export async function getOwnerUser(): Promise<User | null> {
 }
 
 /**
+ * Plex reports the server owner in /status/sessions and SSE payloads with the
+ * local admin user id "1", while server sync and history imports know the same
+ * person by their plex.tv account id. Left as-is, the owner's first playback
+ * mints a fresh server user + identity under external id "1" (splitting their
+ * history and breaking user-scoped rules for them). Canonicalize the alias to
+ * the owner's plex.tv account id whenever that account is known.
+ *
+ * The owner lookup is cached briefly: this runs on every mapped session, and
+ * the owner's plex account id changes at most once (initial linking).
+ */
+let cachedOwnerPlexAccountId: { value: string | null; fetchedAt: number } | null = null;
+const OWNER_PLEX_ACCOUNT_ID_TTL_MS = 60_000;
+
+export async function canonicalPlexExternalUserId(externalUserId: string): Promise<string> {
+  if (externalUserId !== '1') return externalUserId;
+  const now = Date.now();
+  if (
+    !cachedOwnerPlexAccountId ||
+    now - cachedOwnerPlexAccountId.fetchedAt > OWNER_PLEX_ACCOUNT_ID_TTL_MS
+  ) {
+    try {
+      const owner = await getOwnerUser();
+      cachedOwnerPlexAccountId = {
+        value: owner?.plexAccountId ? String(owner.plexAccountId) : null,
+        fetchedAt: now,
+      };
+    } catch {
+      // Session processing must not die on an owner lookup hiccup; fall back
+      // to the raw id and retry the lookup on the next session.
+      return externalUserId;
+    }
+  }
+  return cachedOwnerPlexAccountId.value ?? externalUserId;
+}
+
+/**
  * Create a new user identity
  */
 export async function createUser(data: {


### PR DESCRIPTION
## Summary

Plex reports the server owner in session payloads (`/status/sessions` and SSE) with the local admin id `"1"`, while sync and history imports know the same person by their plex.tv account id. So the owner's first playback after user sync has run creates a duplicate server user and identity under external id `"1"`, splitting their history and breaking user-scoped rules.

Merging doesn't fix it: the duplicate comes back on the next playback.

On my install I can't say for sure how the duplicate first appeared - whether from a live session or from the Tautulli history import that added the plex.tv-keyed account. Both paths end up in the same state, and the re-minting after every merge is reproducible either way.

<details>
<summary>DB evidence - before the fix (current release image)</summary>

Queries run with psql inside the supervised container (username and plex.tv id masked):

```sql
SELECT su.external_id, su.plex_account_id, su.username, u.role, su.created_at
FROM server_users su JOIN users u ON u.id = su.user_id
WHERE su.username = 'allquiet-hub' ORDER BY su.created_at;

SELECT id, username, plex_account_id, role, created_at
FROM users WHERE username ILIKE 'allquiet-hub%' ORDER BY created_at;

SELECT s.media_title, s.state, s.started_at
FROM sessions s JOIN server_users su ON su.id = s.server_user_id
WHERE su.external_id = '1' ORDER BY s.started_at DESC LIMIT 3;
```

```text
 external_id | plex_account_id |   username   |  role  |          created_at
-------------+-----------------+--------------+--------+-------------------------------
 1489****    | 1489****        | allquiet-hub | owner  | 2025-12-18 21:11:55.748742+00
 1           |                 | allquiet-hub | member | 2026-08-14 01:30:11.107933+00
(2 rows)

                  id                  |   username   | plex_account_id |  role  |          created_at
--------------------------------------+--------------+-----------------+--------+-------------------------------
 b94b4e51-14df-425f-8b6a-287c4e3cbfea | allquiet-hub | 1489****        | owner  | 2025-12-18 21:11:55.7397+00
 25c588d6-01cb-4606-b73d-a1d89efb2e1c | allquiet-hub |                 | member | 2026-08-14 01:30:11.107933+00
(2 rows)

 media_title  |  state  |         started_at
--------------+---------+----------------------------
 これからの話 | stopped | 2026-08-14 01:30:11.139+00
(1 row)
```

The ghost account (external id `1`, empty plex.tv id, role `member`) is created at 01:30:11.107 and the session that triggered it starts at 01:30:11.139 - 32 ms later. The account is minted by session processing itself.
</details>

Fix: resolve the `"1"` alias to the owner's plex.tv account id when mapping Plex sessions, in both the poller and SSE paths.

<details>
<summary>DB evidence - after the fix (image built from this branch)</summary>

Same queries as above, after merging the duplicate and playing again as the owner:

```text
 external_id | plex_account_id |   username   |  role  |          created_at
-------------+-----------------+--------------+--------+-------------------------------
 1489****    | 1489****        | allquiet-hub | owner  | 2025-12-18 21:11:55.748742+00
(1 row)

                  id                  |   username   | plex_account_id |  role  |         created_at
--------------------------------------+--------------+-----------------+--------+-----------------------------
 b94b4e51-14df-425f-8b6a-287c4e3cbfea | allquiet-hub | 1489****        | owner  | 2025-12-18 21:11:55.7397+00
(1 row)

 media_title | state | started_at
-------------+-------+------------
(0 rows)
```

A single account remains and no session is attached to external id `1` (0 rows). The owner session landed on the existing plex.tv account.
</details>

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

Found and reproduced on my own installation. Can open an issue first if you want.

## Changes

- New `canonicalPlexExternalUserId()` in `userService`: ids other than `"1"` pass through untouched; `"1"` resolves to the owner's plex.tv account id. Lookup cached for 60s and fail-open: on a db error it returns the raw id instead of killing session processing.
- Both Plex ingest paths (`poller/processor.ts`, `sseProcessor.ts`) canonicalize right after `mapMediaSession`, gated on `server.type === 'plex'`.
- Unit tests: passthrough without touching the db, alias resolution, cache TTL, fallbacks (owner without linked plex.tv account, db error).

## Testing

- [x] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

Manual test on my own server (Plex, ~15 users, Tautulli history imported): before the fix, any owner playback recreated the duplicate user, even after every merge. With the fix deployed, owner sessions land on the existing plex.tv account and no duplicate appears.

Local suite note: 3 pre-existing `webRoot.test.ts` failures on Windows checkouts (tests expect `/`, `path.relative` returns `\`). Unrelated - those files are identical to `main`.

## AI Disclosure

- [x] AI tools were used significantly in writing this code

I'm a C# developer and don't know TypeScript syntax well, so the code and tests were written with Claude Code. The rest is mine: I found and reproduced the bug on my server, verified the PMS `accounts` table invariant behind the `"1"` alias, tested the fix live, and reviewed the diff line by line - I can explain and defend every part of it.

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed, and I can explain every part of this diff
- [ ] For features: discussed with a code owner first (linked above)
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Plex session processing so sessions belonging to the server owner are consistently matched to the correct Plex account.
  - Prevented duplicate or incorrectly associated user records caused by Plex’s local owner identifier.
  - Added resilient handling for account lookup failures, allowing normal processing to continue and retry later.
  - Improved consistency across live session updates, polling, caching, and session history.

- **Tests**
  - Added coverage for owner mapping, caching, missing accounts, and lookup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->