### PR TITLE
feat(rules): configurable header and timeout for Message Client action

### DIFF
--- a/apps/server/src/services/rules/__tests__/executors.test.ts
+++ b/apps/server/src/services/rules/__tests__/executors.test.ts
@@ -778,7 +778,49 @@ describe('Action Executor Registry', () => {
         const result = await executeAction(context, action);
 
         expect(result.success).toBe(true);
-        expect(mockDeps.sendClientMessage).toHaveBeenCalledWith(context.session.id, 'Please stop!');
+        expect(mockDeps.sendClientMessage).toHaveBeenCalledWith(
+          context.session.id,
+          'Please stop!',
+          undefined,
+          undefined
+        );
+      });
+
+      it('should pass header and timeout_ms through to sendClientMessage', async () => {
+        const context = createMockContext();
+        const action: MessageClientAction = {
+          type: 'message_client',
+          message: 'Maintenance tonight',
+          header: 'Whitehorse',
+          timeout_ms: 30000,
+        };
+
+        await executeAction(context, action);
+
+        expect(mockDeps.sendClientMessage).toHaveBeenCalledWith(
+          context.session.id,
+          'Maintenance tonight',
+          'Whitehorse',
+          30000
+        );
+      });
+
+      it('should pass timeout_ms 0 through (persistent display)', async () => {
+        const context = createMockContext();
+        const action: MessageClientAction = {
+          type: 'message_client',
+          message: 'Persistent notice',
+          timeout_ms: 0,
+        };
+
+        await executeAction(context, action);
+
+        expect(mockDeps.sendClientMessage).toHaveBeenCalledWith(
+          context.session.id,
+          'Persistent notice',
+          undefined,
+          0
+        );
       });
 
       it('should not send if message is empty', async () => {
@@ -808,8 +850,8 @@ describe('Action Executor Registry', () => {
           await executeAction(context, action);
 
           expect(mockDeps.sendClientMessage).toHaveBeenCalledTimes(2);
-          expect(mockDeps.sendClientMessage).toHaveBeenCalledWith('s1', 'Warning!');
-          expect(mockDeps.sendClientMessage).toHaveBeenCalledWith('s2', 'Warning!');
+          expect(mockDeps.sendClientMessage).toHaveBeenCalledWith('s1', 'Warning!', undefined, undefined);
+          expect(mockDeps.sendClientMessage).toHaveBeenCalledWith('s2', 'Warning!', undefined, undefined);
         });
       });
     });

--- a/apps/server/src/services/rules/executors/index.ts
+++ b/apps/server/src/services/rules/executors/index.ts
@@ -74,7 +74,12 @@ export interface ActionExecutorDeps {
     // Returns the kill queue job id when a job was created or already exists,
     // or undefined when the enqueue was dropped (queue not initialized).
   ) => Promise<string | undefined>;
-  sendClientMessage: (sessionId: string, message: string) => Promise<void>;
+  sendClientMessage: (
+    sessionId: string,
+    message: string,
+    header?: string,
+    timeoutMs?: number
+  ) => Promise<void>;
   checkCooldown: (ruleId: string, targetId: string, cooldownMinutes: number) => Promise<boolean>;
   setCooldown: (ruleId: string, targetId: string, cooldownMinutes: number) => Promise<void>;
   queueForConfirmation: (params: {
@@ -402,6 +407,8 @@ const executeMessageClient: ActionExecutor = async (
   if (!session) return;
   const typedAction = action as MessageClientAction;
   const message = typedAction.message;
+  const header = typedAction.header;
+  const timeoutMs = typedAction.timeout_ms;
   const target = typedAction.target ?? 'triggering';
 
   if (!message) {
@@ -426,7 +433,7 @@ const executeMessageClient: ActionExecutor = async (
   });
 
   for (const targetSession of sessionsToMessage) {
-    await currentDeps.sendClientMessage(targetSession.id, message);
+    await currentDeps.sendClientMessage(targetSession.id, message, header, timeoutMs);
   }
 };
 

--- a/apps/server/src/services/rules/v2Integration.ts
+++ b/apps/server/src/services/rules/v2Integration.ts
@@ -222,7 +222,7 @@ export function createActionExecutorDeps(redis: Redis): ActionExecutorDeps {
      * Send a message to the client device.
      * Plex does not support client messaging - only Jellyfin/Emby do.
      */
-    sendClientMessage: async (sessionId, message) => {
+    sendClientMessage: async (sessionId, message, header, timeoutMs) => {
       // Get session with server info to determine server type
       const session = await db.query.sessions.findFirst({
         where: eq(sessions.id, sessionId),
@@ -252,7 +252,12 @@ export function createActionExecutorDeps(redis: Redis): ActionExecutorDeps {
 
       // Jellyfin/Emby use sessionKey for API calls
       if ('sendMessage' in client && typeof client.sendMessage === 'function') {
-        await client.sendMessage(session.sessionKey, message, 'Tracearr', 10000);
+        // timeout_ms === 0 means "no auto-dismiss": omit TimeoutMs so
+        // Jellyfin web renders a persistent dialog (its toast is a fixed
+        // ~3.3s and ignores the value entirely). Absent keeps the previous
+        // default of 10000 for backward compatibility.
+        const resolvedTimeout = timeoutMs === 0 ? undefined : (timeoutMs ?? 10000);
+        await client.sendMessage(session.sessionKey, message, header ?? 'Tracearr', resolvedTimeout);
         rulesLogger.debug('Client message sent', { sessionId, message });
       }
     },

--- a/apps/web/src/lib/rules/actionDefinitions.ts
+++ b/apps/web/src/lib/rules/actionDefinitions.ts
@@ -246,6 +246,26 @@ export const ACTION_DEFINITIONS: Record<ActionType, ActionDefinition> = {
         placeholder: 'Message to display...',
         description: 'Text shown to the user',
       },
+      {
+        name: 'header',
+        label: 'Header',
+        type: 'text',
+        placeholder: 'Tracearr',
+        description: 'Title shown above the message (defaults to "Tracearr")',
+      },
+      {
+        name: 'timeout_ms',
+        label: 'Timeout',
+        type: 'number',
+        min: 0,
+        max: 600000,
+        step: 1000,
+        unit: 'ms',
+        description:
+          'Auto-dismiss after this many milliseconds (default 10000). ' +
+          'Set 0 for a persistent dialog on Jellyfin web that stays until dismissed. ' +
+          'TV clients show a brief toast regardless of this value.',
+      },
     ],
   },
 };

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -591,6 +591,8 @@ export const killStreamActionSchema = z.object({
 export const messageClientActionSchema = z.object({
   type: z.literal('message_client'),
   message: z.string().min(1).max(500),
+  header: z.string().max(100).optional(),
+  timeout_ms: z.number().int().min(0).max(600000).optional(),
   target: sessionTargetSchema.optional(),
 });
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -730,6 +730,15 @@ export interface KillStreamAction {
 export interface MessageClientAction {
   type: 'message_client';
   message: string;
+  /** Optional title shown above the message. Defaults to 'Tracearr'. */
+  header?: string;
+  /**
+   * Auto-dismiss timeout in milliseconds. Defaults to 10000 (previous
+   * behavior). Set to 0 to omit TimeoutMs from the Jellyfin/Emby payload:
+   * Jellyfin web then renders a persistent dialog the user must dismiss,
+   * instead of a ~3s toast that ignores the value.
+   */
+  timeout_ms?: number;
   target?: SessionTarget;
 }
 


### PR DESCRIPTION
# feat(rules): configurable header and timeout for the Message Client action

## Problem

The `message_client` rule action hardcodes both the header and the display timeout
(`v2Integration.ts`: `client.sendMessage(session.sessionKey, message, 'Tracearr', 10000)`).

This has two user-facing consequences on Jellyfin:

1. **Every message is branded "Tracearr"** — server admins sending policy or
   maintenance messages to their users can't set their own title.
2. **Messages are unreadable on Jellyfin web.** Because `TimeoutMs` is always
   set, jellyfin-web takes its toast branch, and that toast is **hardcoded to
   3.3 seconds, ignores the TimeoutMs value, and drops the header entirely**
   (see `src/components/toast/toast.ts` — `animateRemove` at 3300 ms, renders
   `options.text` only). Longer messages cannot be read in time.

   jellyfin-web's other branch is the useful one: when `TimeoutMs` is
   **absent**, `serverNotifications.js` renders `alert({ title, text })` — a
   persistent dialog with the header shown, dismissed by the user.

## Change

Adds two optional fields to `MessageClientAction`, fully backward compatible:

- `header?: string` — message title; defaults to `'Tracearr'` (unchanged).
- `timeout_ms?: number` — auto-dismiss in ms; defaults to `10000` (unchanged).
  **`0` means "no auto-dismiss"**: `TimeoutMs` is omitted from the payload so
  Jellyfin web shows the persistent dialog instead of the fixed 3.3 s toast.

Touched:

- `packages/shared/src/types.ts`, `packages/shared/src/schemas.ts` — new
  optional fields (zod: `header` max 100, `timeout_ms` int 0–600000).
- `apps/server/src/services/rules/executors/index.ts` — thread both through
  `sendClientMessage` deps.
- `apps/server/src/services/rules/v2Integration.ts` — resolve defaults; `0`
  maps to `undefined` so `JSON.stringify` drops the key in the media server
  client payload.
- `apps/web/src/lib/rules/actionDefinitions.ts` — Header text field and
  Timeout number field on the action config, with the web/TV behavior
  documented in the field description.
- `apps/server/src/services/rules/__tests__/executors.test.ts` — existing
  assertions updated for the new arity; new tests for header/timeout
  passthrough and the `timeout_ms: 0` case.

## Behavior notes

- Existing rules without the new fields behave exactly as before.
- TV clients (official Android TV, Wholphin) render server messages as a
  fixed ~3.5 s OS toast and ignore `TimeoutMs` regardless — noted in the UI
  field description so users aren't surprised. (Client-side fix is being
  pursued separately with those projects.)
- Plex is unaffected (no client messaging support, unchanged guard).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional headers to client messages.
  * Added configurable message timeouts, including the ability to disable the timeout with a value of zero.
  * Added validation and configuration guidance for the new message options.

* **Bug Fixes**
  * Ensured headers and timeout settings are consistently applied across targeted sessions.
  * Preserved the default 10-second timeout when no custom value is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->