### PR TITLE
fix(server): tolerate Tautulli get_users without do_notify

### DIFF
--- a/apps/server/src/services/__tests__/tautulli.test.ts
+++ b/apps/server/src/services/__tests__/tautulli.test.ts
@@ -916,6 +916,39 @@ describe('TautulliUsersResponseSchema', () => {
     const result = TautulliUsersResponseSchema.safeParse(response);
     expect(result.success).toBe(true);
   });
+
+  it('should accept users without do_notify (Tautulli nightly removed the field)', () => {
+    const response = {
+      response: {
+        result: 'success',
+        message: null,
+        data: [
+          {
+            user_id: 0,
+            username: 'Local',
+            friendly_name: 'Local',
+            thumb: null,
+            email: null,
+            is_home_user: null,
+            is_admin: 0,
+            is_active: 1,
+          },
+          {
+            user_id: 150112024,
+            username: 'Gallapagos',
+            friendly_name: 'Gallapagos',
+            thumb: 'https://plex.tv/users/ceac7bee6aac8175/avatar?c=1764478418',
+            email: 'connor.gallopo@gmail.com',
+            is_home_user: 1,
+            is_admin: 1,
+            is_active: 1,
+          },
+        ],
+      },
+    };
+    const result = TautulliUsersResponseSchema.safeParse(response);
+    expect(result.success).toBe(true);
+  });
 });
 
 // ============================================================================

--- a/apps/server/src/services/tautulli.ts
+++ b/apps/server/src/services/tautulli.ts
@@ -157,7 +157,9 @@ export const TautulliUserRecordSchema = z.object({
   is_home_user: z.number().nullable(), // Can be null for local users
   is_admin: z.number(),
   is_active: z.number(),
-  do_notify: z.number(),
+  // Legacy per-user notification toggle. Tautulli removed do_notify from
+  // get_users (nightly branch, and upcoming stable); Tracearr never uses it.
+  do_notify: z.number().optional(),
 });
 
 export const TautulliUsersResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Tautulli's `get_users` API no longer returns `do_notify` (removed on the `nightly` branch, and the removal will ship with the next stable). Tracearr's `TautulliUserRecordSchema` requires `do_notify: z.number()` on every user record, so the entire users response fails Zod validation and the Tautulli import connection test fails with `Invalid Tautulli API response: expected number, received undefined` for every record.

`do_notify` is parsed but never used anywhere in Tracearr, so making it optional has no behavioral impact.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

## Related Issue

Closes #1066

## Changes

- `apps/server/src/services/tautulli.ts`: `do_notify: z.number()` → `z.number().optional()` with a comment explaining the removal.
- `apps/server/src/services/__tests__/tautulli.test.ts`: regression test — a users response without `do_notify` (the current Tautulli nightly shape) parses successfully.

## Testing

- [x] Added/updated unit tests
- [x] Ran test suite locally (`pnpm test:unit`)
- [x] Tested manually

<!-- Manual testing: the equivalent patch was applied to a deployed Tracearr instance against a live Tautulli nightly
     (get_users returning 181 records without do_notify). The connection test previously failed with the exact
     error above; after the patch it succeeds and the import runs. -->

## AI Disclosure

- [x] AI tools were used significantly in writing this code

<!-- Fix and regression test were drafted with AI assistance, then reviewed and verified manually. -->

## Checklist

- [x] Code follows project style (ran `pnpm lint` and `pnpm format`)
- [x] Self-reviewed, and I can explain every part of this diff
- [ ] A maintainer agreed to this change first (discussion or confirmed issue linked above)
- [x] No new warnings from `pnpm typecheck`
- [x] Tests pass locally
