### PR TITLE
Preserve transcode reasons from Jellystat backup import

### DIFF
--- a/apps/server/src/services/__tests__/jellystat.test.ts
+++ b/apps/server/src/services/__tests__/jellystat.test.ts
@@ -18,6 +18,7 @@ import {
   parseJellystatBackup,
   transformActivityToSession,
   importJellystatBackup,
+  extractJellystatStreamDetails,
 } from '../jellystat.js';
 
 // Import schemas for validation tests
@@ -474,6 +475,66 @@ describe('parseJellystatBackup', () => {
 // ============================================================================
 // TRANSFORMATION TESTS
 // ============================================================================
+
+describe('extractJellystatStreamDetails', () => {
+  it('should thread TranscodeReasons into transcodeInfo.reasons', () => {
+    const result = extractJellystatStreamDetails(null, {
+      VideoCodec: 'h264',
+      AudioCodec: 'aac',
+      Container: 'ts',
+      IsVideoDirect: false,
+      IsAudioDirect: false,
+      HardwareAccelerationType: null,
+      TranscodeReasons: ['ContainerBitrateExceedsLimit'],
+    });
+
+    expect(result.transcodeInfo?.reasons).toEqual(['ContainerBitrateExceedsLimit']);
+  });
+
+  it('should trim, drop empty strings, and dedupe TranscodeReasons', () => {
+    const result = extractJellystatStreamDetails(null, {
+      TranscodeReasons: [
+        ' VideoCodecNotSupported ',
+        'ContainerBitrateExceedsLimit',
+        '',
+        'VideoCodecNotSupported',
+      ],
+    });
+
+    expect(result.transcodeInfo?.reasons).toEqual([
+      'VideoCodecNotSupported',
+      'ContainerBitrateExceedsLimit',
+    ]);
+  });
+
+  it('should leave transcodeInfo.reasons absent when TranscodeReasons is empty or missing', () => {
+    const noReasons = extractJellystatStreamDetails(null, {
+      TranscodeReasons: [],
+      Container: 'ts',
+    });
+    expect(noReasons.transcodeInfo?.reasons).toBeUndefined();
+    expect(noReasons.transcodeInfo?.streamContainer).toBe('ts');
+
+    const noTranscoding = extractJellystatStreamDetails(null, null);
+    expect(noTranscoding.transcodeInfo).toBeNull();
+  });
+
+  it('should coercively handle non-string TranscodeReasons elements', () => {
+    // The interface types TranscodeReasons as string[], but Jellystat backups are
+    // not schema-validated at this layer, so a malformed backup could carry
+    // non-string entries. parseString() coerces them defensively.
+    const result = extractJellystatStreamDetails(null, {
+      TranscodeReasons: [
+        'ContainerBitrateExceedsLimit',
+        null,
+        undefined,
+        42,
+      ] as unknown as string[],
+    });
+
+    expect(result.transcodeInfo?.reasons).toEqual(['ContainerBitrateExceedsLimit', '42']);
+  });
+});
 
 describe('transformActivityToSession', () => {
   // Mock GeoIP result

--- a/apps/server/src/services/jellystat.ts
+++ b/apps/server/src/services/jellystat.ts
@@ -34,7 +34,7 @@ import {
 import { enqueueMaintenanceJob } from '../jobs/maintenanceQueue.js';
 import { batchGetLibraryItemIdentity, type SessionIdentity } from '../jobs/poller/database.js';
 import { sanitizeCodec } from '../utils/codecNormalizer.js';
-import { extractIpFromEndpoint } from '../utils/parsing.js';
+import { extractIpFromEndpoint, parseString } from '../utils/parsing.js';
 import { normalizeClient } from '../utils/platformNormalizer.js';
 import { parseJellystatPlayMethod } from '../utils/transcodeNormalizer.js';
 import type { PubSubService } from './cache.js';
@@ -247,6 +247,21 @@ export function extractJellystatStreamDetails(
     if (transcodingInfo.Container) transcodeDetails.streamContainer = transcodingInfo.Container;
     if (transcodingInfo.HardwareAccelerationType) {
       transcodeDetails.hwEncoding = transcodingInfo.HardwareAccelerationType;
+    }
+
+    // Transcode reasons (e.g. ContainerBitrateExceedsLimit, VideoCodecNotSupported)
+    // Coerce elements defensively, trim, and dedupe so the stored list is clean.
+    if (transcodingInfo.TranscodeReasons?.length) {
+      const reasons = Array.from(
+        new Set(
+          transcodingInfo.TranscodeReasons.map((reason) => parseString(reason).trim()).filter(
+            (reason) => reason.length > 0
+          )
+        )
+      );
+      if (reasons.length > 0) {
+        transcodeDetails.reasons = reasons;
+      }
     }
 
     if (Object.keys(transcodeDetails).length > 0) {


### PR DESCRIPTION
## Summary

The Jellystat backup import was silently **dropping transcode reasons** for every imported session. The import threaded `Container` and `HardwareAccelerationType` into session `transcodeInfo`, but never read `TranscodeReasons` — so the reason a stream was transcoded (e.g. `ContainerBitrateExceedsLimit`, `ContainerNotSupported`) was lost for all historical sessions.

This means the "Transcode Reason" the UI already displays for live Jellyfin/Emby sync (in `StreamDetailsPanel` / `SessionDetailSheet`) was empty for anything imported from a Jellystat backup.

## Root cause

`extractJellystatStreamDetails` is the **single** builder of an imported session's `transcodeInfo` (used by both `transformActivityToSession` and the import loop). It assembled `transcodeInfo` from only `Container` + `HardwareAccelerationType` — `TranscodeReasons` was declared on the source interface but never mapped.

## Change

- **`apps/server/src/services/jellystat.ts`** — thread `TranscodingInfo.TranscodeReasons` → `transcodeDetails.reasons`, mirroring the defensive pattern already used for the same field in `jellyfinEmbyUtils.ts`:
  - `parseString(...).trim()` for resilient coercion
  - drop empty strings
  - dedupe via `Set`
  - only set when non-empty (leaves field absent otherwise, consistent with existing behavior)
- **`apps/server/src/services/__tests__/jellystat.test.ts`** — add `extractJellystatStreamDetails` tests covering:
  - mapping reasons → `transcodeInfo.reasons`
  - trim / drop-empty / dedupe
  - leaving `reasons` absent when empty/missing
  - defensive coercion of non-string elements (backups aren't schema-validated at this layer)

## Verification

- Real-data check against a Jellystat backup (1700 session records with `TranscodeReasons`): previous logic populated reasons for **0/1700**; new logic **1700/1700**.
- `extractJellystatStreamDetails` tests: **4 passed** (name-filtered)
- Full service suite: **3181 passed / 0 failed**
- `tsc --noEmit` clean, ESLint 0 errors, Prettier clean
- Pre-push hooks (typecheck / test:unit / lint / translations) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transcoding reasons from Jellystat.
  * Transcoding reasons are now cleaned, trimmed, deduplicated, and empty values are excluded.
  * Invalid or non-text values are handled safely.
  * The reasons field is omitted when no valid reasons are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->